### PR TITLE
Distro image creation now supports additional packages

### DIFF
--- a/scripts/create
+++ b/scripts/create
@@ -19,6 +19,7 @@
 NAME=${NAME:-$1}
 DISTRO=${DISTRO:-debian}
 SIZE=${SIZE:-8G}
+PKGS=${PKGS:-$2}
 
 set -e
 
@@ -47,11 +48,11 @@ trap cleanup EXIT
 
 if [ $DISTRO == "debian" ]; then
     debootstrap \
-	--include=less,locales-all,vim,sudo,openssh-server,jed,pciutils,bash-completion,psmisc,htop,pydf\
+	--include=less,locales-all,vim,sudo,openssh-server,jed,pciutils,bash-completion,psmisc,htop,pydf,${PKGS}\
 	stable mnt
 elif [ $DISTRO == "ubuntu" ]; then
     debootstrap \
-	--include=less,vim,sudo,openssh-server,pciutils,bash-completion,psmisc,htop,tmux,curl,wget,emacs25-nox,htop,dnsutils \
+	--include=less,vim,sudo,openssh-server,pciutils,bash-completion,psmisc,htop,tmux,curl,wget,emacs25-nox,htop,dnsutils,${PKGS}\
 	bionic mnt
 else
     echo "${DISTRO} distro not supported by deboostrap"

--- a/scripts/setup
+++ b/scripts/setup
@@ -55,7 +55,7 @@ EOF
 cat > mnt/etc/fstab << EOF
 LABEL=swap none  swap   sw   0   0
 LABEL=rootfs /     ext4   errors=remount-ro,noatime   0   0
-home  /home 9p     trans=virtio,version=9p2000.L,nofail   0   0
+shared  /shared 9p     trans=virtio,version=9p2000.L,nofail   0   0
 EOF
 
 if [ $MOUNT_NVME == "yes" ]; then


### PR DESCRIPTION
Added option to add additional packages to distro image creation script
on command line.  This helps with image-setup when automating testing
of kernel images using qemu.