### PR TITLE
gen-image: Add a script to generate a cloud-init based image

### DIFF
--- a/scripts/gen-image
+++ b/scripts/gen-image
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# (C) 2020 Stephen Bates (stephen@eideticom)
+# (C) 2022 Martin Oliveira (martin.oliveira@eideticom)
+#
+# A script to generate a Ubuntu image for testing the performance of NVMe
+# devices in virtual environments.
+#
+# For Ubuntu hosts, you might need to install cloud-image-utils (or cloud-utils
+# on RHEL)
+
+set -e
+
+NAME=${NAME:-qemu-minimal}
+USERNAME=${USERNAME:-eid}
+PASS=${PASS:-password}
+IMAGE_SIZE=${IMAGE_SIZE:-8}
+RELEASE=${RELEASE:-jammy}
+ARCH=${ARCH:-amd64}
+SSH_KEY_FILE=${SSH_KEY_FILE:-none}
+
+IMG="${RELEASE}-server-cloudimg-${ARCH}.img"
+
+# User *must* provide an ssh key
+if [ $SSH_KEY_FILE == "none" ]; then
+    echo "Must specify a SSH_KEY_FILE!"
+    exit 1
+elif [ ! -f $SSH_KEY_FILE ]; then
+     echo "SSH_KEY_FILE ${SSH_KEY_FILE} does not exist!"
+     exit 1
+fi
+
+cat << EOF > cloud-config-${NAME}
+#cloud-config
+hostname: ${NAME}
+disable_root: true
+ssh_pwauth: true
+users:
+  - name: ${USERNAME}
+    plain_text_passwd: '${PASS}'
+    lock_passwd: false
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: users, admin
+    shell: /bin/bash
+    ssh_authorized_keys: |
+      $(sed -z 's|\n|\n      |g' ${SSH_KEY_FILE})
+packages:
+  -ansible
+EOF
+
+cat << EOF > network-config-${NAME}
+version: 2
+ethernets:
+  [en*]:
+     dhcp4: true
+     # default QEMU userspace network
+     gateway4: 10.0.2.2
+     nameservers:
+       addresses: [ 10.0.2.3, 8.8.8.8 ]
+EOF
+
+if [ ! -f ../images/${IMG} ]; then
+    wget https://cloud-images.ubuntu.com/${RELEASE}/current/${IMG} \
+	 -O ../images/${IMG}
+fi
+
+cp ../images/${IMG} ../images/${NAME}.qcow2
+qemu-img resize ../images/${NAME}.qcow2 ${IMAGE_SIZE}G
+cloud-localds -v --network-config=network-config-${NAME} \
+	      ../images/${NAME}-seed.raw cloud-config-${NAME}
+
+rm -f cloud-config-${NAME} network-config-${NAME}


### PR DESCRIPTION
Cloud-init provides a very nice way to setup a quick image file for a VM based on Ubuntu releases for amd64 and arm64. This script automates this process and is based on a script developed by Martin. This script generates two images and when booted runs a cloud-init process to setup the first user.

Fixes #10.