### PR TITLE
virt-install-ubuntu: Add an option to include package install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ scripts/initramfs.cpio.gz
 scripts/image.img
 scripts/rootfs
 libvirt/hostname.tmp
+libvirt/focal-*.img
+libvirt/jammy-*.img
 *~

--- a/libvirt/packages.d/packages-default
+++ b/libvirt/packages.d/packages-default
@@ -1,0 +1,16 @@
+# packages-default: My default list of initial packages.
+# Note indent by 2 spaces and use a hyphen!
+  - bmon
+  - build-essential
+  - emacs-nox
+  - fio
+  - git
+  - gnuplot
+  - gpg-agent
+  - libaio-dev
+  - liburing-dev
+  - python2
+  - python3-pip
+  - mutt
+  - sysstat
+  - tree

--- a/libvirt/packages.d/packages-minimal
+++ b/libvirt/packages.d/packages-minimal
@@ -1,0 +1,6 @@
+# packages-default: My minimal list of initial packages
+# Note indent by 2 spaces and use a hyphen!
+  - emacs-nox
+  - fio
+  - sysstat
+  - tree

--- a/libvirt/virt-install-ubuntu
+++ b/libvirt/virt-install-ubuntu
@@ -49,8 +49,12 @@
 # Note that after running this script you might want to remove the
 # cloud-init disk from the VM. See [1] for info on how to do that.
 
-# Note that the variables ARCH, SSH_KEY_FILE, USERNAME, PASS  and
-# NOAUTOCONSOLE only apply to focal or later.
+# Note that the variables ARCH, SSH_KEY_FILE, USERNAME, PASS,
+# NOAUTOCONSOLE and PACKAGES only apply to focal or later.
+#
+# PACKAGES is a file of packages to be installed via cloud-init. A
+# couple of my favourite collections can be found in the packages.d
+# folder.
 
 NAME=${NAME:-qemu-minimal}
 KS=${KS:-none}
@@ -62,6 +66,7 @@ SSH_KEY_FILE=${SSH_KEY_FILE:-~/.ssh/id_rsa.pub}
 NOAUTOCONSOLE=${NOAUTOCONSOLE:-false}
 USERNAME=${USERNAME:-ubuntu}
 PASS=${PASS:-password}
+PACKAGES=${PACKAGES:-none}
 
 if [ $RELEASE == "bionic" ]; then
 
@@ -134,6 +139,17 @@ if [ ! -f $SSH_KEY_FILE ]; then
      exit 1
 fi
 
+if [ ${PACKAGES} != "none" ]; then
+    if [ -f ${PACKAGES} ]; then
+	PACKAGES=$(<${PACKAGES})
+    else
+	echo "Package manifest file ${PACKAGES} does not exist!"
+	exit 1
+    fi
+else
+    PACKAGES=
+fi
+
 cat << EOF > cloud-config-${NAME}
 #cloud-config
 hostname: ${NAME}
@@ -148,6 +164,8 @@ users:
     shell: /bin/bash
     ssh_authorized_keys: |
       $(sed -z 's|\n|\n      |g' ${SSH_KEY_FILE})
+packages:
+${PACKAGES}
 power_state:
   delay: now
   mode: poweroff


### PR DESCRIPTION
cloud-init allows the user to specify a manifest of packages to be installed at initialization time. Add support for this in virt-install-ubuntu. Also add a couple of example manifests that I find useful.

Fixes #23.