### PR TITLE
run-vm-cxl-nvme: Add script that runs NVMe behind CXL

### DIFF
--- a/qemu/run-vm-cxl-nvme
+++ b/qemu/run-vm-cxl-nvme
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# run-vm-cxl-nvme
+#
+# (C) Stephen Bates <stephen.bates@huawei.com>
+# (C) Stephen Bates <sbates@raithlin.com>
+#
+# A simple script to run an Ubuntu based VM on Huawei systems. This
+# script tries to create an emulated CXL bus and places an NVMe device
+# on that bus (see Stephen's conversations with Jonathan Cameron in
+# May 2023).
+#
+# Note this script is special for a couple of reasons:
+#   1. No KVM, Jonathan thinks TCG is needed for CXL emulation.
+#   2. We have to use a recent kernel but we also need the CXL drivers
+#      to be modules (install via install-kernel script).
+
+VM_NAME=${VM_NAME:-qemu-minimal}
+VCPUS=${VCPUS:-2}
+MEMORY=${MEMORY:-4G}
+NVME_SIZE=${NVME_SIZE:-64G}
+FS_PATH=${FS_PATH:-/home/${USER}/Projects}
+SSH_PORT=${SSH_PORT:-2224}
+KERNEL_PATH=${KERNEL_PATH:-../kernels}
+KERNEL_NAME=${KERNEL_NAME:-bzImage-cxl-nvme}
+QEMU_DIR=${QEMU_DIR:-}
+IMAGES=${IMAGES:-../images}
+
+if [ ! -f  ${IMAGES}/${VM_NAME}-nvme.qcow2 ]; then
+    qemu-img create -f qcow2 ${IMAGES}/${VM_NAME}-nvme.qcow2 $NVME_SIZE
+fi
+
+#  -kernel ${KERNEL_PATH}/${KERNEL_NAME} \
+#  -append 'root=/dev/vda1 console=ttyS0' \
+
+${QEMU_DIR}qemu-system-x86_64 \
+  -machine type=q35,cxl=on \
+  -smp cpus=${VCPUS} \
+  -m ${MEMORY} \
+  -nographic \
+  -drive if=none,file=${IMAGES}/${VM_NAME}.qcow2,format=qcow2,id=root-hd \
+  -device virtio-blk-pci,drive=root-hd \
+  -device pcie-root-port,id=root_port1 \
+  -virtfs local,id=hostfs,path=${FS_PATH},security_model=mapped,mount_tag=hostfs \
+  -device virtio-net-pci,netdev=net0 \
+  -netdev user,id=net0,hostfwd=tcp::${SSH_PORT}-:22 \
+  -object memory-backend-file,id=cxl-mem,share=on,mem-path=/tmp/${VM_NAME}-cxl.raw,size=256M \
+  -object memory-backend-file,id=cxl-lsa,share=on,mem-path=/tmp/${VM_NAME}-lsa.ram,size=256M \
+  -device pxb-cxl,bus_nr=12,bus=pcie.0,id=cxl.1,\
+  -device cxl-rp,port=0,bus=cxl.1,id=cxl_rp_port0,chassis=0,slot=2 \
+  -device cxl-rp,port=1,bus=cxl.1,id=cxl_rp_port1,chassis=0,slot=3 \
+  -device cxl-upstream,bus=cxl_rp_port0,id=us0 \
+  -device cxl-downstream,port=0,bus=us0,id=cxl_ds_port0,chassis=0,slot=4 \
+  -device cxl-downstream,port=1,bus=us0,id=cxl_ds_port1,chassis=0,slot=5 \
+  -device virtio-rng,bus=cxl_rp_port1,addr=0.1 \
+  -device cxl-type3,bus=cxl_ds_port0,memdev=cxl-mem,id=cxl-mem1,lsa=cxl-lsa,sn=4 \
+  -machine cxl-fmw.0.targets.0=cxl.1,cxl-fmw.0.size=4G,cxl-fmw.0.interleave-granularity=1k \
+  -drive file=${IMAGES}/${VM_NAME}-nvme.qcow2,id=${VM_NAME}-nvme,format=qcow2,if=none \
+  -device nvme,serial=deadbeef,bus=cxl_ds_port1,drive=${VM_NAME}-nvme \
+
+#  -device pcie-root-port,id=pcie_rp_port0,bus=pcie.0 \
+#  -drive format=qcow2,file=${IMAGES}/${VM_NAME}.qcow2,id=root \
+#  -drive file=${IMAGES}/${VM_NAME}-nvme.qcow2,id=${VM_NAME}-nvme,format=qcow2 \
+#  -device nvme,serial=deadbeef,bus=cxl_ds_port1,drive=${VM_NAME}-nvme \
+
+


### PR DESCRIPTION
Add a short script that shows how we can put an NVMe SSD below a CXL bus and thus explore that world where NVMe and CXL meet.