### PR TITLE
virt-install-ubuntu: Add timezone

### DIFF
--- a/libvirt/virt-install-ubuntu
+++ b/libvirt/virt-install-ubuntu
@@ -180,6 +180,9 @@ users:
     shell: /bin/bash
     ssh_authorized_keys: |
       $(sed -z 's|\n|\n      |g' ${SSH_KEY_FILE})
+timezone: America/Edmonton
+ntp:
+  enabled: true"
 packages:
 ${PACKAGES}
 power_state:


### PR DESCRIPTION
Add a default timezone to oour cloud-init so we always have that as we want it.