### PR TITLE
qemu/gen-vm: Fix a small bug in path to images folder

### DIFF
--- a/qemu/gen-vm
+++ b/qemu/gen-vm
@@ -62,7 +62,7 @@ if [ ! -f  ${IMAGES}/${RELEASE}-server-cloudimg-${ARCH}.img ]; then
     wget -P ${IMAGES} https://cloud-images.ubuntu.com/${RELEASE}/current/${RELEASE}-server-cloudimg-${ARCH}.img
 fi
 cp ${IMAGES}/${RELEASE}-server-cloudimg-${ARCH}.img ${IMAGES}/${VM_NAME}-backing.qcow2
-qemu-img resize ~/images/${VM_NAME}-backing.qcow2 ${SIZE}G
+qemu-img resize ${IMAGES}/${VM_NAME}-backing.qcow2 ${SIZE}G
 
 if [ ! -f $SSH_KEY_FILE ]; then
      echo "SSH_KEY_FILE ${SSH_KEY_FILE} does not exist!"


### PR DESCRIPTION
There was a spot where I had forgotten to change a hard-coded reference to the images folder to a variable-based one. So let's fix that while we are here.