### PR TITLE
run-vm: Add -cpu EPYC switch to enable p2pdma for x86_64

### DIFF
--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -58,7 +58,7 @@ fi
 
 if [ ${ARCH} == "amd64" ]; then
     QARCH="x86_64"
-    QARCH_ARGS="-machine q35${KVM}"
+    QARCH_ARGS="-machine q35${KVM} -cpu EPYC"
 elif [ ${ARCH} == "arm64" ]; then
     QARCH="aarch64"
     QARCH_ARGS="-machine virt,gic-version=max${KVM} -cpu max -bios /usr/share/qemu-efi-aarch64/QEMU_EFI.fd"


### PR DESCRIPTION
The default x86_64 arguments enable a platform that is not whitelisted in Linux for p2pdma. So we alter that to add EPYC as the generic CPU type when ARCH is set appropriately.