### PR TITLE
vfio-setup: Add a script to help with vfio device setup

### DIFF
--- a/qemu/vfio-setup
+++ b/qemu/vfio-setup
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# vfio-setup
+#
+# (C) Stephen Bates <sbates@raithlin>
+#
+# A simple bash script to setup devices for vfio-based passthru into a
+# VM. Note that to make IOMMU setup easier you can create some udev
+# rules for permissions on the /dev/vfio files that are created. Use
+# the commands below to set that up on your system.
+#
+#   /etc/udev/rules.d/70-vfio-group.rules
+#   SUBSYSTEM=="vfio", GROUP="kvm", MODE="0660"
+#   sudo udevadm control --reload-rules
+#   sudo udevadm trigger
+#
+# Note that this script makes use of the very useful driverctl
+# program.
+
+# HOST_ADDR is the PCI address for the target device.
+# SKIP_UNBIND skips the unbind step. This can be useful when the
+#   device is already unbound.
+# BIN_DRIVER is the driver to bind too. This is normally going to be
+#   vfio-pci. However you can set it to something else if you want.
+# CHECK_ONLY just outputs the driver that the HOST_ADDR device is
+#   currently bound too.
+# LIST_ONLY outputs all devices that are currently bound to the
+#   BIND_DRIVER driver. Useful to see the current state of affairs.
+
+set -e
+
+HOST_ADDR=${HOST_ADDR:-none}
+BIND_DRIVER=${BIND_DRIVER:-vfio-pci}
+CHECK_ONLY=${CHECK_ONLY:-false}
+LIST_ONLY=${LIST_ONLY:-false}
+
+if [[ ${EUID} -ne 0 ]]; then
+   echo "This script must be run as root. Please use 'sudo'."
+   exit 1
+fi
+
+if command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: driverctl is not installed. Exiting."
+    exit 1
+fi
+
+function get_driver () {
+    VALUE=$(ls -lrth /sys/bus/pci/devices/${1}/ | grep driver | grep drivers | sed 's/.*\///')
+    echo $VALUE
+}
+
+function bind () {
+    driverctl set-override ${HOST_ADDR} ${BIND_DRIVER}
+}
+
+function unbind () {
+    driverctl unset-override ${HOST_ADDR}
+}
+
+if [ $LIST_ONLY == "true" ]; then
+    echo "INFO: Active overrides..."
+    driverctl -b pci -v list-overrides
+    echo "INFO: Persistent overrides..."
+    driverctl -b pci -v list-persisted
+    exit 0
+fi
+
+if [[ ! -d /sys/bus/pci/devices/${HOST_ADDR} ]]; then
+    echo "ERROR: PCI device ${HOST_ADDR} does not exist. Exiting."
+    exit 1
+fi
+DRIVER=$(get_driver ${HOST_ADDR})
+
+if [ $CHECK_ONLY == true ]; then
+    echo "INFO: CHECK_ONLY, the drive for ${HOST_ADDR} is ${DRIVER}."
+    exit 0
+fi
+if [[ -z ${DRIVER} ]]; then
+    echo "ERROR: Could not detect driver for PCI device ${HOST_ADDR}."
+    if [ $FORCE_BIND == true ]; then
+        echo "INFO: FORCE_BIND is true. Attempting to continue."
+        SKIP_UNBIND=true
+    else
+        exit 1
+    fi
+else
+    echo "INFO: PCI device ${HOST_ADDR} is bound to the ${DRIVER} driver."
+fi
+sleep 0.25
+if [ $SKIP_UNBIND == "false" ]; then
+    echo "INFO: Unbinding PCI device ${HOST_ADDR} from the ${DRIVER} driver."
+    unbind ${HOST_ADDR} ${DRIVER}
+fi
+sleep 0.25
+echo "INFO: Binding PCI device ${HOST_ADDR} to the ${BIND_DRIVER} driver."
+bind ${HOST_ADDR} ${BIND_DRIVER}
+sleep 0.25


### PR DESCRIPTION
Setting up a PCI device to pass into a VM can be a bit tricky. So we provide a helper function to assist in this.