### PR TITLE
refactor: rename to RESTORE_IMAGE and preserve backing file timestamps

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,7 +30,7 @@ jobs:
         KVM: none
         USERNAME: ubuntu
         PASS: password
-    - name: Test RESTORE_FROM_BACKING mode
+    - name: Test RESTORE_IMAGE mode
       run: |
         # Remove the main image to simulate corruption/deletion
         rm -f ../images/qemu-minimal-smoke-test.qcow2
@@ -39,9 +39,9 @@ jobs:
           echo "Failed to remove image for test"
           exit 1
         fi
-        # Restore from backing file using RESTORE_FROM_BACKING mode
+        # Restore from backing file using RESTORE_IMAGE mode
         VM_NAME=qemu-minimal-smoke-test \
-          RESTORE_FROM_BACKING=true \
+          RESTORE_IMAGE=true \
           ./gen-vm
         # Verify the image was recreated with backing file
         if [ ! -f ../images/qemu-minimal-smoke-test.qcow2 ]; then
@@ -53,7 +53,7 @@ jobs:
           echo "Restored image does not have backing file"
           exit 1
         fi
-        echo "✓ RESTORE_FROM_BACKING mode test passed"
+        echo "✓ RESTORE_IMAGE mode test passed"
       working-directory: qemu
     - name: Run the generated x86_64 VM as a background task
       run: ./run-vm > run-vm-output.log 2>&1 &

--- a/qemu/gen-vm
+++ b/qemu/gen-vm
@@ -39,7 +39,7 @@
 # backing file or not. This is useful in some cases for exporting the
 # image files to other people. The default is to use a backing file.
 #
-# RESTORE_FROM_BACKING is a boolean that only performs the final qemu-img
+# RESTORE_IMAGE is a boolean that only performs the final qemu-img
 # create step. Before running, it checks that qemu is not using the
 # image file and that the backing file exists.
 
@@ -60,7 +60,7 @@ SSH_PORT=${SSH_PORT:-2222}
 KVM=${KVM:-enable}
 FORCE=${FORCE:-false}
 NO_BACKING=${NO_BACKING:-false}
-RESTORE_FROM_BACKING=${RESTORE_FROM_BACKING:-false}
+RESTORE_IMAGE=${RESTORE_IMAGE:-false}
 
   # Focal and above prefers us to use cloud images and
   # cloud-init. Download the focal cloud image and set it up using a
@@ -77,16 +77,27 @@ trap cleanup SIGINT ERR EXIT
 
 # Function to create a qcow2 image with a backing file
 create_image_with_backing() {
+    # Save backing file timestamp before qemu-img accesses it
+    local backing_timestamp=$(stat -c %y ${2} 2>/dev/null || \
+                              stat -f %Sm -t "%Y-%m-%d %H:%M:%S" ${2})
+    
     qemu-img create -F qcow2 -b ${2} -f qcow2 ${1}
+    
+    # Restore backing file timestamp after qemu-img accessed it
+    if [ -n "${backing_timestamp}" ]; then
+        touch -d "${backing_timestamp}" ${2} 2>/dev/null || \
+            touch -t $(date -j -f "%Y-%m-%d %H:%M:%S" \
+                "${backing_timestamp}" +%Y%m%d%H%M.%S 2>/dev/null) ${2}
+    fi
 }
 
-# Handle RESTORE_FROM_BACKING option - only perform the final
+# Handle RESTORE_IMAGE option - only perform the final
 # qemu-img create step. This mode takes precedence over all other
 # modes and exits after completion.
-if [ ${RESTORE_FROM_BACKING} == "true" ]; then
+if [ ${RESTORE_IMAGE} == "true" ]; then
     # Check for conflicting options
     if [ ${NO_BACKING} == "true" ]; then
-        echo "Error: RESTORE_FROM_BACKING and NO_BACKING cannot both" \
+        echo "Error: RESTORE_IMAGE and NO_BACKING cannot both" \
              "be true!"
         exit 1
     fi


### PR DESCRIPTION
Rename RESTORE_FROM_BACKING to RESTORE_IMAGE for clarity and fix issue where qemu-img create was modifying backing file timestamps.

Changes:
- Rename RESTORE_FROM_BACKING to RESTORE_IMAGE throughout
- Update create_image_with_backing() to preserve backing file timestamps
  - Save timestamp before qemu-img create accesses the backing file
  - Restore timestamp after qemu-img completes
  - Cross-platform compatible (Linux/macOS)
- Update smoke-test workflow to use RESTORE_IMAGE
- Fix whitespace consistency

The timestamp preservation ensures the backing file appears untouched by RESTORE_IMAGE operations, which is important for tracking when the base image was last updated.