### PR TITLE
feat: add PCIe root ports to enable atomic operations

### DIFF
--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -78,8 +78,9 @@ function nvme_create {
     if [ ! -f ${IMAGES}/${1}.qcow2 ]; then
         qemu-img create -f qcow2 ${IMAGES}/${1}.qcow2 $2 >> /dev/null
     fi
-    echo "-drive file=${IMAGES}/${1}.qcow2,format=qcow2,if=none,id=nvme-${3}"\
-         "-device nvme,serial=${1},drive=nvme-${3} "
+    local port_id="rp_nvme${3}"
+    echo "-drive file=${IMAGES}/${1}.qcow2,format=qcow2,if=none,id=nvme-${3} "\
+         "-device nvme,serial=${1},drive=nvme-${3},bus=${port_id} "
 }
 
   # Check that the user has provided valid PCIe bus addresses and also check
@@ -97,14 +98,23 @@ function pci_check () {
     fi
 }
 
+# Create PCIe root ports for NVMe devices to enable proper PCIe topology
+# and atomic operation support
+PCIE_ROOT_PORTS=""
 if [ ${NVME} == "none" ]; then
     NVME_ARGS=""
 elif [ ${NVME} == "true" ]; then
-    NVME_ARGS=$(echo "-drive file=/dev/nullb0,format=raw,if=none,id=nvme-1"\
-                     "-device nvme,serial=${VM_NAME}-nvme1,drive=nvme-1 ")
+    PCIE_ROOT_PORTS+="-device pcie-root-port,id=rp_nvme1,"
+    PCIE_ROOT_PORTS+="chassis=1,slot=1 "
+    NVME_ARGS=$(echo "-drive file=/dev/nullb0,format=raw,if=none,id=nvme-1 "\
+                     "-device nvme,serial=${VM_NAME}-nvme1,drive=nvme-1,"\
+                     "bus=rp_nvme1 ")
 elif [[ ${NVME} =~ ^[0-9]+$ ]]; then
     NVME_ARGS=""
     for i in $(seq 1 ${NVME}); do
+        # Create a PCIe root port for each NVMe device
+        PCIE_ROOT_PORTS+="-device pcie-root-port,id=rp_nvme${i},"
+        PCIE_ROOT_PORTS+="chassis=${i},slot=${i} "
         NVME_NAME=${VM_NAME}-nvme${i}
         NVME_ARGS+=$(nvme_create ${NVME_NAME} ${NVME_SIZE} ${i})
     done
@@ -121,9 +131,25 @@ fi
 if [ ${PCI_HOSTDEV} == "none" ]; then
     PCI_HOSTDEV_ARGS=""
 else
+    # Calculate starting chassis/slot for host devices (after NVMe devices)
+    if [[ ${NVME} =~ ^[0-9]+$ ]]; then
+        HOST_PORT_START=$((${NVME} + 1))
+    elif [ ${NVME} == "true" ]; then
+        HOST_PORT_START=2
+    else
+        HOST_PORT_START=1
+    fi
+    
+    HOST_PORT_NUM=${HOST_PORT_START}
     for THIS_PCI_HOSTDEV in ${PCI_HOSTDEV//,/ }; do
         pci_check ${THIS_PCI_HOSTDEV}
-        PCI_HOSTDEV_ARGS+="-device vfio-pci,host=${THIS_PCI_HOSTDEV} "
+        # Create PCIe root port for host device
+        PCIE_ROOT_PORTS+="-device pcie-root-port,id=rp_host${HOST_PORT_NUM},"
+        PCIE_ROOT_PORTS+="chassis=${HOST_PORT_NUM},slot=${HOST_PORT_NUM} "
+        # Attach vfio-pci device to the root port
+        PCI_HOSTDEV_ARGS+="-device vfio-pci,host=${THIS_PCI_HOSTDEV},"
+        PCI_HOSTDEV_ARGS+="bus=rp_host${HOST_PORT_NUM} "
+        HOST_PORT_NUM=$((HOST_PORT_NUM + 1))
     done
 fi
 
@@ -133,6 +159,7 @@ ${QEMU_PATH}qemu-system-${QARCH} \
    -m ${VMEM} \
    ${FILESYSTEM_ARGS} \
    -nographic \
+   ${PCIE_ROOT_PORTS} \
    ${NVME_ARGS} \
    ${PCI_TESTDEV_ARGS} \
    ${PCI_HOSTDEV_ARGS} \


### PR DESCRIPTION
Add proper PCIe topology to run-vm by creating dedicated PCIe root ports for NVMe and PCI passthrough devices. This enables PCIe atomic operation support in guest VMs, which is required for AMD ROCm, DPDK, and other high-performance computing workloads.

Changes:
- Modify nvme_create() to attach NVMe devices to PCIe root ports
  - Changed from direct attachment to using bus=rp_nvme${i}
  - Enables proper PCIe hierarchy for atomic operation routing
- Add PCIE_ROOT_PORTS generation for NVMe devices
  - Creates pcie-root-port for each NVMe device (NVME=true or NVME=N)
  - Assigns unique chassis and slot numbers starting at 1
- Add PCIE_ROOT_PORTS generation for PCI_HOSTDEV devices
  - Creates pcie-root-port for each vfio-pci passthrough device
  - Calculates chassis/slot numbers to avoid conflicts with NVMe
  - Ensures proper isolation for each passthrough device
- Update QEMU command line to include ${PCIE_ROOT_PORTS}
- Maintain 80-column compliance throughout

PCIe Topology Created:
  Root Complex (q35) ├─ pcie-root-port (rp_nvme1, chassis=1, slot=1)
    │    └─ nvme device 1
    ├─ pcie-root-port (rp_nvme2, chassis=2, slot=2)
    │    └─ nvme device 2
    ├─ pcie-root-port (rp_host3, chassis=3, slot=3)
    │    └─ vfio-pci host device 1
    └─ ...

Technical Details:
- PCIe atomics (32bit/64bit) properly exposed to guest devices
- AtomicOpsCtl: ReqEn+ confirmed on AMD GPU passthrough
- Compatible with QEMU 8.2.2+ (no special properties required)
- Default QEMU PCIe root port settings enable atomic routing

Benefits:
- Enables AMD ROCm compute workloads (requires atomic operations)
- Supports DPDK and high-performance networking applications
- Proper PCIe device isolation and error handling
- Better alignment with real hardware PCIe topology
- Backward compatible with existing VM configurations

Tested with:
  VM_NAME=test NVME=1 PCI_HOSTDEV=10:00.0,c2:00.0,c3:00.0,c3:00.1 \ VCPUS=16 VMEM=16384 FILESYSTEM=/home/user/Projects ./run-vm

Verification:
- lspci -vvv confirms AtomicOpsCap: 32bit+ 64bit+ 128bitCAS-
- lspci -vvv confirms AtomicOpsCtl: ReqEn+ on passthrough GPU
- rocminfo successfully detects GPU with atomic support
- KFD device node /dev/kfd created for ROCm workloads