### PR TITLE
linux-generic: Add to default package install

### DIFF
--- a/packages.d/packages-default
+++ b/packages.d/packages-default
@@ -14,6 +14,7 @@
   - gpg-agent
   - libaio-dev
   - liburing-dev
+  - linux-generic
   - nvme-cli
   - moreutils
   - pahole


### PR DESCRIPTION
Add this meta-package so we always get headers and extra modules.