### PR TITLE
run-vm: add pcie-root-port for VFIO_USERDEV and QMP socket

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -380,6 +380,41 @@ jobs:
         echo "✓ custom VCPUS/VMEM passed"
       working-directory: qemu
 
+    - name: "Dry-run: VFIO_USERDEV with pcie-root-port"
+      run: |
+        out=$(VM_NAME=dry-test KVM=none \
+              VFIO_USERDEV=/tmp/a.sock,/tmp/b.sock \
+              DRY_RUN=1 ./run-vm)
+        echo "$out"
+        echo "$out" | grep -q \
+          "pcie-root-port,id=pcie-vfu.1"
+        echo "$out" | grep -q \
+          "pcie-root-port,id=pcie-vfu.2"
+        echo "$out" | grep -q "vfio-user-pci"
+        echo "✓ VFIO_USERDEV root-port passed"
+      working-directory: qemu
+
+    - name: "Dry-run: QMP_SOCKET=true"
+      run: |
+        out=$(VM_NAME=dry-test KVM=none \
+              QMP_SOCKET=true DRY_RUN=1 ./run-vm)
+        echo "$out"
+        echo "$out" | grep -q \
+          "unix:/tmp/qmp-dry-test-2222.sock"
+        echo "✓ QMP_SOCKET=true passed"
+      working-directory: qemu
+
+    - name: "Dry-run: QMP_SOCKET=custom path"
+      run: |
+        out=$(VM_NAME=dry-test KVM=none \
+              QMP_SOCKET=/tmp/my-qmp.sock \
+              DRY_RUN=1 ./run-vm)
+        echo "$out"
+        echo "$out" | grep -q \
+          "unix:/tmp/my-qmp.sock"
+        echo "✓ QMP_SOCKET custom path passed"
+      working-directory: qemu
+
   smoke-test-arm64:
     name: smoke-test-arm64
     runs-on: ubuntu-latest

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -20,8 +20,10 @@ Initramfs
 KVM
 LFS
 LightNVM
+MCAST
 MMIO
 Matias
+Multicast
 Multistrap
 NIC
 NVM
@@ -35,6 +37,7 @@ PCIe
 PMEM
 PRs
 Passthrough
+QMP
 QEMU
 QEMU's
 README

--- a/README.md
+++ b/README.md
@@ -135,8 +135,10 @@ using it before restoring.
 | `NVME_TRACE` | `none` | NVMe tracing (`doorbell`, `all`, or event name) |
 | `NVME_TRACE_FILE` | (empty) | Redirect trace output to a file |
 | `PCI_HOSTDEV` | `none` | Comma-separated PCI addresses for VFIO passthrough |
-| `VFIO_USERDEV` | `none` | Comma-separated libvfio-user socket paths |
+| `VFIO_USERDEV` | `none` | libvfio-user sockets (each under a root-port) |
 | `PCI_MMIO_BRIDGE` | `none` | pci-mmio-bridge for CXL-style testing |
 | `PCI_TESTDEV` | `none` | Enable pci-testdev |
 | `DATA_NIC_QUEUES` | `0` | Multi-queue virtio-net TAP NIC (queue count) |
+| `MCAST_GROUP` | `none` | Multicast socket NIC (`230.0.0.1:1234`) |
+| `QMP_SOCKET` | `false` | QMP socket (`true` for default, or path) |
 | `DRY_RUN` | `none` | Print QEMU command instead of executing |

--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -65,7 +65,14 @@
 # Post 10.1.0 versions of QEMU have libvfio-user support which allows
 # us to create emulated PCIe devices via a socket and the API provided
 # by that library. You can specify these device(s) via a comma-separated
-# list of sockets in VFIO_USERDEV.
+# list of sockets in VFIO_USERDEV. Each device is placed below its own
+# pcie-root-port to enable hot-plug and PCIe topology isolation.
+#
+# QMP_SOCKET enables the QEMU Machine Protocol monitor socket:
+#   - "false" (default): no QMP socket
+#   - "true": adds a QMP unix socket at
+#     /tmp/qmp-${VM_NAME}-${SSH_PORT}.sock
+#   - Any other value is treated as a custom socket path
 #
 # DATA_NIC_QUEUES adds a second multi-queue virtio-net NIC backed
 # by a TAP device (named dt<SSH_PORT>, e.g. dt2231).  This is
@@ -109,6 +116,7 @@ PCI_MMIO_BRIDGE=${PCI_MMIO_BRIDGE:-none}
 DATA_NIC_QUEUES=${DATA_NIC_QUEUES:-0}
 DRY_RUN=${DRY_RUN:-none}
 MCAST_GROUP=${MCAST_GROUP:-none}
+QMP_SOCKET=${QMP_SOCKET:-false}
 
 if [ "${KVM}" = "enable" ]; then
     KVM=",accel=kvm"
@@ -289,15 +297,23 @@ fi
 if [ "${VFIO_USERDEV}" = "none" ]; then
     VFIO_USERDEV_ARGS=()
 else
-    VFIO_USERDEV_ARGS+=( -object memory-backend-memfd,id=mem-vfio-user,size=${VMEM},share=on  )
+    VFIO_USERDEV_ARGS+=( -object \
+        memory-backend-memfd,id=mem-vfio-user,size=${VMEM},share=on )
     VFIO_USERDEV_ARGS+=( -numa node,memdev=mem-vfio-user )
+    j=0
     for THIS_VFIO_USERDEV in ${VFIO_USERDEV//,/ }; do
-        if [ ! -S "${THIS_VFIO_USERDEV}" ]; then
-            echo "ERROR: Socket ${THIS_VFIO_USERDEV} does not exist."
+        if [ "${DRY_RUN}" = "none" ] \
+                && [ ! -S "${THIS_VFIO_USERDEV}" ]; then
+            echo "ERROR: Socket ${THIS_VFIO_USERDEV}" \
+                "does not exist."
             exit 1
         fi
-        DEV_JSON=$(printf '{"driver":"vfio-user-pci","socket":{"path":"%s","type":"unix"}}' \
-            "${THIS_VFIO_USERDEV}")
+        j=$((j + 1))
+        VFIO_USERDEV_ARGS+=( \
+            -device "pcie-root-port,id=pcie-vfu.${j}" )
+        DEV_JSON=$(printf \
+            '{"driver":"vfio-user-pci","bus":"pcie-vfu.%d","socket":{"path":"%s","type":"unix"}}' \
+            "${j}" "${THIS_VFIO_USERDEV}")
         VFIO_USERDEV_ARGS+=( -device "${DEV_JSON}" )
     done
 fi
@@ -363,6 +379,16 @@ if [ "${MCAST_GROUP}" != "none" ]; then
     MCAST_ARGS+=",mac=${MCAST_MAC}"
 fi
 
+QMP_ARGS=""
+if [ "${QMP_SOCKET}" != "false" ]; then
+    if [ "${QMP_SOCKET}" = "true" ]; then
+        QMP_SOCKET_PATH="/tmp/qmp-${VM_NAME}-${SSH_PORT}.sock"
+    else
+        QMP_SOCKET_PATH="${QMP_SOCKET}"
+    fi
+    QMP_ARGS="-qmp unix:${QMP_SOCKET_PATH},server,nowait"
+fi
+
 QEMU_CMD=(${QEMU_PATH}qemu-system-${QARCH}
    ${QARCH_ARGS}
    ${TRACE_ARGS}
@@ -379,7 +405,8 @@ QEMU_CMD=(${QEMU_PATH}qemu-system-${QARCH}
    -netdev user,id=net0,hostfwd=tcp::${SSH_PORT}-:22
    -device virtio-net-pci,netdev=net0
    ${DATA_NIC_ARGS}
-   ${MCAST_ARGS})
+   ${MCAST_ARGS}
+   ${QMP_ARGS})
 
 if [ "${DRY_RUN}" != "none" ]; then
     echo "${QEMU_CMD[@]}"


### PR DESCRIPTION
Place each libvfio-user device below its own pcie-root-port (pcie-vfu.N) so the guest can hot-plug devices and gets proper PCIe topology isolation, matching the existing PCI_HOSTDEV behaviour.

Add QMP_SOCKET (default false). Set to "true" for a socket at /tmp/qmp-${VM_NAME}-${SSH_PORT}.sock, or pass a custom path. The flag appends "-qmp unix:<path>,server,nowait" to the QEMU command line.

Skip the VFIO_USERDEV socket-existence check in DRY_RUN mode so CI dry-run tests work without real sockets.

Update README.md env-var table (VFIO_USERDEV description, MCAST_GROUP, QMP_SOCKET) and add three new dry-run CI tests covering VFIO_USERDEV root-port output and both QMP_SOCKET modes.