### PR TITLE
run-vm: fix memfd size unit for VFIO_USERDEV memory backend

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -66,6 +66,29 @@ jobs:
         fi
         echo "✓ RESTORE_IMAGE mode test passed"
       working-directory: qemu
+    - name: Test BACKING_FILE mode
+      run: |
+        BACKING_FILE=../images/qemu-minimal-smoke-test-backing.qcow2 \
+          VM_NAME=shared-overlay-test \
+          ./gen-vm
+        if [ ! -f ../images/shared-overlay-test.qcow2 ]; then
+          echo "Overlay not created by BACKING_FILE mode"
+          exit 1
+        fi
+        if ! qemu-img info \
+             ../images/shared-overlay-test.qcow2 \
+             | grep -q "backing file:"; then
+          echo "Overlay does not reference a backing file"
+          exit 1
+        fi
+        if ! qemu-img info \
+             ../images/shared-overlay-test.qcow2 \
+             | grep -q "smoke-test-backing"; then
+          echo "Overlay does not point to expected backing"
+          exit 1
+        fi
+        echo "✓ BACKING_FILE mode test passed"
+      working-directory: qemu
     - name: Run the generated x86_64 VM as a background task
       run: ./run-vm > run-vm-output.log 2>&1 &
       working-directory: qemu
@@ -413,6 +436,33 @@ jobs:
         echo "$out" | grep -q \
           "unix:/tmp/my-qmp.sock"
         echo "✓ QMP_SOCKET custom path passed"
+      working-directory: qemu
+
+    - name: "Dry-run: BACKING_SHARED=true adds file.locking=off"
+      run: |
+        out=$(VM_NAME=dry-test KVM=none \
+              BACKING_SHARED=true \
+              DRY_RUN=1 ./run-vm)
+        echo "$out"
+        echo "$out" | grep -q "file.locking=off"
+        echo "$out" | grep -q "backing.file.locking=off"
+        echo "✓ BACKING_SHARED dry-run passed"
+      working-directory: qemu
+
+    - name: "Dry-run: BACKING_SHARED default has no file.locking"
+      run: |
+        out=$(VM_NAME=dry-test KVM=none \
+              DRY_RUN=1 ./run-vm)
+        echo "$out"
+        if echo "$out" | grep -q "file.locking=off"; then
+          echo "file.locking=off should not appear by default"
+          exit 1
+        fi
+        if echo "$out" | grep -q "backing.file.locking=off"; then
+          echo "backing.file.locking=off should not appear by default"
+          exit 1
+        fi
+        echo "✓ BACKING_SHARED default dry-run passed"
       working-directory: qemu
 
   smoke-test-arm64:

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -28,6 +28,7 @@ Multistrap
 NIC
 NVM
 NVME
+OFD
 NVMe
 NVMf
 OpenChannel

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Set `PACKAGES=none` to skip package installation entirely.
 | `FORCE` | `false` | Force re-download of cloud image |
 | `NO_BACKING` | `false` | Create image without backing file |
 | `RESTORE_IMAGE` | `false` | Recreate image from existing backing file |
+| `BACKING_FILE` | (empty) | Path to existing backing qcow2 for overlay creation |
 
 ### RESTORE_IMAGE
 
@@ -117,6 +118,17 @@ file. This is useful when the VM image is corrupted or
 deleted but the backing file remains. The script verifies
 that the backing file exists and that QEMU is not currently
 using it before restoring.
+
+### BACKING_FILE
+
+When `BACKING_FILE` is set to a path, `gen-vm` skips the
+cloud image download, cloud-init provisioning, and first
+boot entirely. Instead it creates `${VM_NAME}.qcow2` as a
+thin qcow2 overlay on top of the specified backing file.
+This allows multiple VMs to share a single read-only
+backing image, with per-VM diffs written to their own
+overlays. See [Shared Backing Files](#shared-backing-files)
+for a full workflow example.
 
 ## Environment Variables (run-vm)
 
@@ -142,3 +154,47 @@ using it before restoring.
 | `MCAST_GROUP` | `none` | Multicast socket NIC (`230.0.0.1:1234`) |
 | `QMP_SOCKET` | `false` | QMP socket (`true` for default, or path) |
 | `DRY_RUN` | `none` | Print QEMU command instead of executing |
+| `BACKING_SHARED` | `false` | Disable image locking for shared backing files |
+
+## Shared Backing Files
+
+Multiple VMs can share a single read-only backing file.
+Each VM gets its own thin overlay where all writes land,
+so the backing file is never modified after provisioning.
+
+1. Create the base VM (runs cloud-init and provisions the
+   backing file):
+
+```bash
+cd qemu
+VM_NAME=base ./gen-vm
+```
+
+2. Create per-VM overlays from the shared backing file:
+
+```bash
+BACKING_FILE=../images/base-backing.qcow2 \
+  VM_NAME=vm1 ./gen-vm
+BACKING_FILE=../images/base-backing.qcow2 \
+  VM_NAME=vm2 ./gen-vm
+```
+
+3. Run each VM with `BACKING_SHARED=true` and a unique
+   `SSH_PORT` so QEMU disables file locking on the
+   backing chain:
+
+```bash
+BACKING_SHARED=true VM_NAME=vm1 \
+  SSH_PORT=2222 ./run-vm &
+BACKING_SHARED=true VM_NAME=vm2 \
+  SSH_PORT=2223 ./run-vm &
+```
+
+`BACKING_SHARED=true` adds `file.locking=off` and
+`backing.file.locking=off` to the root disk `-drive`.
+The first disables QEMU's OFD locking on the overlay;
+the second disables it on the backing file that QEMU
+opens internally. Both are needed to prevent lock
+conflicts across instances sharing the same backing
+file. Each VM must still use a distinct `VM_NAME` (and
+therefore a distinct overlay) to avoid data corruption.

--- a/qemu/gen-vm
+++ b/qemu/gen-vm
@@ -42,6 +42,14 @@
 # RESTORE_IMAGE is a boolean that only performs the final qemu-img
 # create step. Before running, it checks that qemu is not using the
 # image file and that the backing file exists.
+#
+# BACKING_FILE is a path to an existing, already-provisioned
+# backing qcow2 image. When set, gen-vm skips the cloud image
+# download, cloud-init provisioning, and first boot, and
+# instead creates ${VM_NAME}.qcow2 as a thin overlay on top
+# of the specified backing file. This allows multiple VMs to
+# share a single read-only backing image with per-VM diffs
+# written to their own overlays.
 
 QEMU_PATH=${QEMU_PATH:-}
 VM_NAME=${VM_NAME:-qemu-minimal}
@@ -61,6 +69,7 @@ KVM=${KVM:-enable}
 FORCE=${FORCE:-false}
 NO_BACKING=${NO_BACKING:-false}
 RESTORE_IMAGE=${RESTORE_IMAGE:-false}
+BACKING_FILE=${BACKING_FILE:-}
 
   # Focal and above prefers us to use cloud images and
   # cloud-init. Download the focal cloud image and set it up using a
@@ -135,6 +144,32 @@ if [ "${RESTORE_IMAGE}" = "true" ]; then
         "${IMAGES}/${VM_NAME}-backing.qcow2"
     echo "Successfully created ${IMAGE_FILE} with backing file" \
          "${IMAGES}/${VM_NAME}-backing.qcow2"
+    exit 0
+fi
+
+# Handle BACKING_FILE option - create an overlay on top of an
+# existing, already-provisioned backing image. This skips
+# cloud-init and first boot entirely.
+if [ -n "${BACKING_FILE}" ]; then
+    if [ "${NO_BACKING}" = "true" ]; then
+        echo "Error: BACKING_FILE and NO_BACKING cannot" \
+             "both be set!"
+        exit 1
+    fi
+    if [ ! -f "${BACKING_FILE}" ]; then
+        echo "Error: BACKING_FILE ${BACKING_FILE} does" \
+             "not exist!"
+        exit 1
+    fi
+
+    mkdir -p "${IMAGES}"
+    IMAGE_FILE="${IMAGES}/${VM_NAME}.qcow2"
+    echo "Creating overlay ${IMAGE_FILE} backed by" \
+         "${BACKING_FILE}"
+    create_image_with_backing "${IMAGE_FILE}" \
+        "${BACKING_FILE}"
+    echo "Successfully created ${IMAGE_FILE} with" \
+         "backing file ${BACKING_FILE}"
     exit 0
 fi
 

--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -91,6 +91,17 @@
 # the same LAN) communicate over a shared multicast segment
 # without any TAP/bridge setup.  A deterministic MAC address
 # is derived from SSH_PORT so each VM gets a unique address.
+#
+# BACKING_SHARED when set to "true" adds file.locking=off
+# and backing.file.locking=off to the root disk -drive
+# option. The first disables QEMU's OFD image locking on
+# the overlay; the second disables it on the backing file
+# that QEMU opens internally. Both are needed so that
+# multiple VMs can open overlays that share the same
+# read-only backing file without lock conflicts. Each VM
+# must still have its own overlay (different VM_NAME).
+# Use gen-vm with BACKING_FILE to create per-VM overlays
+# from a shared backing image.
 
 set -e
 
@@ -117,6 +128,7 @@ DATA_NIC_QUEUES=${DATA_NIC_QUEUES:-0}
 DRY_RUN=${DRY_RUN:-none}
 MCAST_GROUP=${MCAST_GROUP:-none}
 QMP_SOCKET=${QMP_SOCKET:-false}
+BACKING_SHARED=${BACKING_SHARED:-false}
 
 if [ "${KVM}" = "enable" ]; then
     KVM=",accel=kvm"
@@ -298,7 +310,7 @@ if [ "${VFIO_USERDEV}" = "none" ]; then
     VFIO_USERDEV_ARGS=()
 else
     VFIO_USERDEV_ARGS+=( -object \
-        memory-backend-memfd,id=mem-vfio-user,size=${VMEM},share=on )
+        memory-backend-memfd,id=mem-vfio-user,size=${VMEM}M,share=on )
     VFIO_USERDEV_ARGS+=( -numa node,memdev=mem-vfio-user )
     j=0
     for THIS_VFIO_USERDEV in ${VFIO_USERDEV//,/ }; do
@@ -389,6 +401,12 @@ if [ "${QMP_SOCKET}" != "false" ]; then
     QMP_ARGS="-qmp unix:${QMP_SOCKET_PATH},server,nowait"
 fi
 
+ROOT_DRIVE="-drive if=virtio,format=qcow2"
+ROOT_DRIVE+=",file=${IMAGES}/${VM_NAME}.qcow2"
+if [ "${BACKING_SHARED}" = "true" ]; then
+    ROOT_DRIVE+=",file.locking=off,backing.file.locking=off"
+fi
+
 QEMU_CMD=(${QEMU_PATH}qemu-system-${QARCH}
    ${QARCH_ARGS}
    ${TRACE_ARGS}
@@ -401,7 +419,7 @@ QEMU_CMD=(${QEMU_PATH}qemu-system-${QARCH}
    ${PCI_HOSTDEV_ARGS}
    "${PCI_MMIO_BRIDGE_ARGS[@]}"
    "${VFIO_USERDEV_ARGS[@]}"
-   -drive if=virtio,format=qcow2,file=${IMAGES}/${VM_NAME}.qcow2
+   ${ROOT_DRIVE}
    -netdev user,id=net0,hostfwd=tcp::${SSH_PORT}-:22
    -device virtio-net-pci,netdev=net0
    ${DATA_NIC_ARGS}


### PR DESCRIPTION
VMEM is specified in megabytes but memory-backend-memfd's size parameter defaults to bytes. Append the M suffix so QEMU allocates the intended amount of shared memory for vfio-user devices.