### PR TITLE
gen-vm: add systemd drop-ins for faster, cleaner shutdown

### DIFF
--- a/qemu/gen-vm
+++ b/qemu/gen-vm
@@ -219,6 +219,7 @@ ${PACKAGES}
 runcmd:
   - systemctl disable openipmi.service
   - systemctl mask openipmi.service
+  - loginctl enable-linger ${USERNAME}
 power_state:
   delay: now
   mode: poweroff
@@ -233,6 +234,20 @@ write_files:
     owner: root:root
     permissions: 0o644
     append: true
+    defer: true
+  - path: /etc/systemd/logind.conf.d/99-kill-user-processes.conf
+    content: |
+      [Login]
+      KillUserProcesses=yes
+    owner: root:root
+    permissions: 0o644
+    defer: true
+  - path: /etc/systemd/system.conf.d/99-timeout.conf
+    content: |
+      [Manager]
+      DefaultTimeoutStopSec=15s
+    owner: root:root
+    permissions: 0o644
     defer: true
   - path: /home/${USERNAME}/.emacs
     content: |


### PR DESCRIPTION
Add two cloud-init write_files entries that deploy systemd drop-in configs into every generated VM:

- logind.conf.d/99-kill-user-processes.conf sets KillUserProcesses=yes so logind terminates all session processes when a user session ends, preventing orphaned processes from lingering during shutdown.

- system.conf.d/99-timeout.conf sets DefaultTimeoutStopSec=15s, reducing the global unit-stop timeout from 90s to 15s so a hung service cannot block shutdown for over a minute.

Uses drop-in directories rather than modifying the vendor- supplied logind.conf / system.conf, so the settings survive base config changes across Ubuntu releases.