### PR TITLE
Add Ubuntu 26.04 support to qemu/gen-vm and matrix smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,8 +12,13 @@ on:
 jobs:
 
   smoke-test-x86:
-    name: smoke-test-x86
+    name: smoke-test-x86-${{ matrix.release }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release:
+          - noble
+          - resolute
     steps:
     - name: Check out code using action/checkout
       uses: actions/checkout@v4.3.1
@@ -28,7 +33,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: images/*-server-cloudimg-*.img
-        key: cloud-img-amd64-noble
+        key: cloud-img-amd64-${{ matrix.release }}
     - name: Ensure images directory exists
       run: mkdir -p images
     - name: Generate a x86_64 qemu-based ./gen-vm smoke-test
@@ -36,6 +41,7 @@ jobs:
       working-directory: qemu
       env:
         VM_NAME: qemu-minimal-smoke-test
+        RELEASE: ${{ matrix.release }}
         KVM: none
         USERNAME: ubuntu
         PASS: password

--- a/qemu/gen-vm
+++ b/qemu/gen-vm
@@ -78,6 +78,20 @@ BACKING_FILE=${BACKING_FILE:-}
 
 set -e
 
+# Accept both codenames (e.g. noble) and versions (e.g. 26.04).
+resolve_cloud_image_info() {
+    local release="$1"
+    local arch="$2"
+
+    if [[ "${release}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        CLOUD_IMAGE_FILE="ubuntu-${release}-server-cloudimg-${arch}.img"
+        CLOUD_IMAGE_URL="https://cloud-images.ubuntu.com/releases/${release}/release/${CLOUD_IMAGE_FILE}"
+    else
+        CLOUD_IMAGE_FILE="${release}-server-cloudimg-${arch}.img"
+        CLOUD_IMAGE_URL="https://cloud-images.ubuntu.com/${release}/current/${CLOUD_IMAGE_FILE}"
+    fi
+}
+
 cleanup() {
     rm -rf cloud-config-${VM_NAME} network-config-${VM_NAME} \
        ${IMAGES}/${VM_NAME}-seed.qcow2
@@ -173,11 +187,13 @@ if [ -n "${BACKING_FILE}" ]; then
     exit 0
 fi
 
-if [ "${FORCE}" = "true" ] || [ ! -f "${IMAGES}/${RELEASE}-server-cloudimg-${ARCH}.img" ]; then
-    rm -rf "${IMAGES}/${RELEASE}-server-cloudimg-${ARCH}.img"
-    wget -P "${IMAGES}" "https://cloud-images.ubuntu.com/${RELEASE}/current/${RELEASE}-server-cloudimg-${ARCH}.img"
+resolve_cloud_image_info "${RELEASE}" "${ARCH}"
+
+if [ "${FORCE}" = "true" ] || [ ! -f "${IMAGES}/${CLOUD_IMAGE_FILE}" ]; then
+    rm -rf "${IMAGES}/${CLOUD_IMAGE_FILE}"
+    wget -P "${IMAGES}" "${CLOUD_IMAGE_URL}"
 fi
-cp "${IMAGES}/${RELEASE}-server-cloudimg-${ARCH}.img" \
+cp "${IMAGES}/${CLOUD_IMAGE_FILE}" \
     "${IMAGES}/${VM_NAME}-backing.qcow2"
 qemu-img resize "${IMAGES}/${VM_NAME}-backing.qcow2" "${SIZE}G"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add release resolution logic in `qemu/gen-vm` to support both codename releases (e.g. `noble`) and numeric releases (e.g. `26.04`)
- build the correct Ubuntu cloud-image filename and download URL based on `RELEASE` format
- keep existing codename behavior unchanged while enabling numeric release paths used by Ubuntu release images
- add an x86 smoke-test matrix in CI to run `gen-vm` for both `noble` and `resolute`, while keeping the same GitHub runner (`ubuntu-latest`)

## Testing
- `bash -n qemu/gen-vm`
- validated generated numeric URL pattern against published release paths using:
  - `https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img`
- confirmed codename URL pattern remains unchanged in script logic
- verified workflow updates by inspection:
  - `smoke-test-x86` now has `strategy.matrix.release: [noble, resolute]`
  - cache key now includes `${{ matrix.release }}`
  - `RELEASE` is passed into the `./gen-vm` step from the matrix value

## Notes
- `shellcheck` is configured in CI, but not available in this runtime environment (`shellcheck: command not found`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53efaf67-08f8-4831-a3db-69f4d9a389f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53efaf67-08f8-4831-a3db-69f4d9a389f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

