### PR TITLE
Add qemu-guest-agent package and QGA socket wiring

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -128,6 +128,14 @@ jobs:
       run: |
         ssh -o NoHostAuthenticationForLocalhost=yes \
           -v -p 2222 ubuntu@localhost ls -ltrh
+    - name: Verify qemu-guest-agent package in guest
+      run: |
+        ssh -o NoHostAuthenticationForLocalhost=yes \
+          -o StrictHostKeyChecking=no \
+          -p 2222 ubuntu@localhost \
+          "dpkg-query -W -f='\${Status}' qemu-guest-agent" \
+          | grep -q "install ok installed"
+        echo "✓ qemu-guest-agent package installed in guest"
 
   smoke-test-x86-nullblk:
     name: smoke-test-x86-nullblk
@@ -243,6 +251,9 @@ jobs:
         echo "$out" | grep -q "\-machine q35"
         echo "$out" | grep -q "\-cpu EPYC"
         echo "$out" | grep -q "\-nographic"
+        echo "$out" | grep -q "/tmp/qga-dry-test-2222.sock"
+        echo "$out" | grep -q "virtserialport,chardev=qga0"
+        echo "$out" | grep -q "org.qemu.guest_agent.0"
         echo "✓ x86 defaults passed"
       working-directory: qemu
 

--- a/qemu/gen-vm
+++ b/qemu/gen-vm
@@ -213,6 +213,14 @@ else
     PACKAGES=
 fi
 
+if ! printf "%s\n" "${PACKAGES}" \
+     | grep -Eq '^[[:space:]]*-[[:space:]]*qemu-guest-agent([[:space:]]|$)'; then
+    if [ -n "${PACKAGES}" ]; then
+        PACKAGES+=$'\n'
+    fi
+    PACKAGES+="  - qemu-guest-agent"
+fi
+
 cat << EOF > cloud-config-${VM_NAME}
 #cloud-config
 hostname: ${VM_NAME}

--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -74,6 +74,10 @@
 #     /tmp/qmp-${VM_NAME}-${SSH_PORT}.sock
 #   - Any other value is treated as a custom socket path
 #
+# QGA_SOCKET_PATH controls the host-side UNIX socket path for the
+# QEMU Guest Agent channel. By default, this is:
+#   /tmp/qga-${VM_NAME}-${SSH_PORT}.sock
+#
 # DATA_NIC_QUEUES adds a second multi-queue virtio-net NIC backed
 # by a TAP device (named dt<SSH_PORT>, e.g. dt2231).  This is
 # useful when a guest application (e.g. Weka DPDK) needs to take
@@ -129,6 +133,7 @@ DRY_RUN=${DRY_RUN:-none}
 MCAST_GROUP=${MCAST_GROUP:-none}
 QMP_SOCKET=${QMP_SOCKET:-false}
 BACKING_SHARED=${BACKING_SHARED:-false}
+QGA_SOCKET_PATH=${QGA_SOCKET_PATH:-/tmp/qga-${VM_NAME}-${SSH_PORT}.sock}
 
 if [ "${KVM}" = "enable" ]; then
     KVM=",accel=kvm"
@@ -401,6 +406,12 @@ if [ "${QMP_SOCKET}" != "false" ]; then
     QMP_ARGS="-qmp unix:${QMP_SOCKET_PATH},server,nowait"
 fi
 
+QGA_ARGS=(
+    -chardev "socket,path=${QGA_SOCKET_PATH},server=on,wait=off,id=qga0"
+    -device virtio-serial
+    -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0
+)
+
 ROOT_DRIVE="-drive if=virtio,format=qcow2"
 ROOT_DRIVE+=",file=${IMAGES}/${VM_NAME}.qcow2"
 if [ "${BACKING_SHARED}" = "true" ]; then
@@ -424,7 +435,8 @@ QEMU_CMD=(${QEMU_PATH}qemu-system-${QARCH}
    -device virtio-net-pci,netdev=net0
    ${DATA_NIC_ARGS}
    ${MCAST_ARGS}
-   ${QMP_ARGS})
+   ${QMP_ARGS}
+   "${QGA_ARGS[@]}")
 
 if [ "${DRY_RUN}" != "none" ]; then
     echo "${QEMU_CMD[@]}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- always include `qemu-guest-agent` in the cloud-init package list emitted by `qemu/gen-vm`
- add a QEMU guest agent chardev + virtio serial port in `qemu/run-vm`
- make the default QGA socket path VM-scoped via `/tmp/qga-${VM_NAME}-${SSH_PORT}.sock`
- extend smoke CI to assert both QGA command-line arguments and guest package installation

## Testing
- `shellcheck -S error qemu/gen-vm qemu/run-vm libvirt/create-nvme libvirt/virt-install-ubuntu`
- `VM_NAME=dry-test KVM=none NVME=none DRY_RUN=1 ./run-vm` (verified QGA args)
- `VM_NAME=dry-test KVM=none QGA_SOCKET_PATH=/tmp/my-qga.sock DRY_RUN=1 ./run-vm` (verified custom QGA socket path)
- `VM_NAME=ci-packages PACKAGES=none SSH_KEY_FILE=/tmp/gen-vm-ci-key.pub FORCE=false KVM=none SIZE=1 RELEASE=noble ARCH=amd64 QEMU_PATH=/bin/true IMAGES=/tmp/gen-vm-images ./gen-vm` (verified cloud-config contains `qemu-guest-agent`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c0a0cf8-ff02-41aa-acd3-35004bca472c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c0a0cf8-ff02-41aa-acd3-35004bca472c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

