### PR TITLE
un-vm: fix AIO override, PCIe chassis, and guest-agent wiring

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -479,6 +479,36 @@ jobs:
         echo "✓ EXTRA_HOSTFWD passed"
       working-directory: qemu
 
+    - name: "Dry-run: EXTRA_HOSTFWD rejects missing leading comma"
+      run: |
+        set +e
+        out=$(VM_NAME=dry-test KVM=none \
+              EXTRA_HOSTFWD="hostfwd=tcp::9150-:9100" \
+              DRY_RUN=1 ./run-vm 2>&1)
+        rc=$?
+        set -e
+        echo "$out"
+        [ $rc -ne 0 ] || \
+          (echo "Expected run-vm to reject EXTRA_HOSTFWD without comma" && exit 1)
+        echo "$out" | grep -q "must start with a comma"
+        echo "✓ EXTRA_HOSTFWD comma check passed"
+      working-directory: qemu
+
+    - name: "Dry-run: EXTRA_HOSTFWD rejects whitespace"
+      run: |
+        set +e
+        out=$(VM_NAME=dry-test KVM=none \
+              EXTRA_HOSTFWD=",hostfwd=tcp::9150-:9100 " \
+              DRY_RUN=1 ./run-vm 2>&1)
+        rc=$?
+        set -e
+        echo "$out"
+        [ $rc -ne 0 ] || \
+          (echo "Expected run-vm to reject EXTRA_HOSTFWD with whitespace" && exit 1)
+        echo "$out" | grep -q "must not contain whitespace"
+        echo "✓ EXTRA_HOSTFWD whitespace check passed"
+      working-directory: qemu
+
     - name: "Dry-run: BACKING_SHARED=true adds file.locking=off"
       run: |
         out=$(VM_NAME=dry-test KVM=none \

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -252,6 +252,7 @@ jobs:
         echo "$out" | grep -q "\-cpu EPYC"
         echo "$out" | grep -q "\-nographic"
         echo "$out" | grep -q "/tmp/qga-dry-test-2222.sock"
+        echo "$out" | grep -q "virtio-serial-pci,id=virtio-serial0"
         echo "$out" | grep -q "virtserialport,chardev=qga0"
         echo "$out" | grep -q "org.qemu.guest_agent.0"
         echo "✓ x86 defaults passed"
@@ -453,6 +454,29 @@ jobs:
         echo "$out" | grep -q \
           "unix:/tmp/my-qmp.sock"
         echo "✓ QMP_SOCKET custom path passed"
+      working-directory: qemu
+
+    - name: "Dry-run: QEMU_GUEST_AGENT=none omits guest agent"
+      run: |
+        out=$(VM_NAME=dry-test KVM=none \
+              QEMU_GUEST_AGENT=none DRY_RUN=1 ./run-vm)
+        echo "$out"
+        if echo "$out" | grep -q "org.qemu.guest_agent.0"; then
+          echo "guest agent should be omitted when QEMU_GUEST_AGENT=none"
+          exit 1
+        fi
+        echo "✓ QEMU_GUEST_AGENT=none passed"
+      working-directory: qemu
+
+    - name: "Dry-run: EXTRA_HOSTFWD appends hostfwd rules"
+      run: |
+        out=$(VM_NAME=dry-test KVM=none \
+              EXTRA_HOSTFWD=",hostfwd=tcp::9150-:9100" \
+              DRY_RUN=1 ./run-vm)
+        echo "$out"
+        echo "$out" | grep -q \
+          "hostfwd=tcp::9150-:9100"
+        echo "✓ EXTRA_HOSTFWD passed"
       working-directory: qemu
 
     - name: "Dry-run: BACKING_SHARED=true adds file.locking=off"

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -13,6 +13,7 @@ Filesystems
 GCP
 GDB
 HOSTDEV
+HOSTFWD
 Hardcoded
 IOMMU
 IPv
@@ -106,6 +107,7 @@ github
 gitignore
 gz
 hardcoded
+hostfwd
 href
 html
 http
@@ -121,6 +123,7 @@ jessie
 kbusch
 kickstart
 ko
+kvm
 lfs
 li
 librxe

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ for a full workflow example.
 | `DATA_NIC_QUEUES` | `0` | Multi-queue virtio-net TAP NIC (queue count) |
 | `MCAST_GROUP` | `none` | Multicast socket NIC (`230.0.0.1:1234`) |
 | `QMP_SOCKET` | `false` | QMP socket (`true` for default, or path) |
+| `QEMU_GUEST_AGENT` | `enable` | Guest agent channel on amd64 (`none` to omit) |
+| `EXTRA_HOSTFWD` | (empty) | Extra user-mode hostfwd rules (comma-prefixed) |
 | `DRY_RUN` | `none` | Print QEMU command instead of executing |
 | `BACKING_SHARED` | `false` | Disable image locking for shared backing files |
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,28 @@ qemu-minimal/
   packages.d/
     packages-default     Default cloud-init package set
     packages-minimal     Minimal cloud-init package set
+  udev/
+    99-qemu-minimal-vfio.rules  VFIO device permissions
+    install-vfio-rules            Install the udev rules
   images/                VM images (created at runtime)
 ```
+
+## VFIO PCI Passthrough
+
+Bind the host device to `vfio-pci`, then pass its PCI address
+to `run-vm` via `PCI_HOSTDEV`. QEMU must be able to open the
+IOMMU group device under `/dev/vfio/N`; by default those
+nodes are root-only.
+
+Install the udev rules once (requires sudo). Your user must
+be in the `kvm` group:
+
+```bash
+./udev/install-vfio-rules
+```
+
+Re-login after group changes. `run-vm` checks VFIO access and
+prints this path if permissions are still wrong.
 
 ## Images Directory
 

--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -303,14 +303,16 @@ else
     PCI_TESTDEV_ARGS="-device pci-testdev,membar=16G,membar-backed=true"
 fi
 
+PCIE_ROOT_PORT_CHASSIS=0
 if [ "${PCI_HOSTDEV}" = "none" ]; then
     PCI_HOSTDEV_ARGS=""
 else
     i=0
     for THIS_PCI_HOSTDEV in ${PCI_HOSTDEV//,/ }; do
         i=$((i + 1))
+        PCIE_ROOT_PORT_CHASSIS=$((PCIE_ROOT_PORT_CHASSIS + 1))
         pci_check "${THIS_PCI_HOSTDEV}"
-        PCI_HOSTDEV_ARGS+="-device pcie-root-port,id=pcie.${i} "
+        PCI_HOSTDEV_ARGS+="-device pcie-root-port,id=pcie.${i},chassis=${PCIE_ROOT_PORT_CHASSIS} "
         PCI_HOSTDEV_ARGS+="-device vfio-pci,bus=pcie.${i},host=${THIS_PCI_HOSTDEV} "
     done
 fi
@@ -330,8 +332,9 @@ else
             exit 1
         fi
         j=$((j + 1))
+        PCIE_ROOT_PORT_CHASSIS=$((PCIE_ROOT_PORT_CHASSIS + 1))
         VFIO_USERDEV_ARGS+=( \
-            -device "pcie-root-port,id=pcie-vfu.${j}" )
+            -device "pcie-root-port,id=pcie-vfu.${j},chassis=${PCIE_ROOT_PORT_CHASSIS}" )
         DEV_JSON=$(printf \
             '{"driver":"vfio-user-pci","bus":"pcie-vfu.%d","socket":{"path":"%s","type":"unix"}}' \
             "${j}" "${THIS_VFIO_USERDEV}")

--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -169,6 +169,7 @@ function qemu_probe_caps {
     local qemu="${QEMU_PATH}qemu-system-${QARCH}"
     QEMU_HAS_IOEVENTFD=0
     QEMU_HAS_DBCS=0
+    local aio_override="${QEMU_AIO:-}"
     QEMU_AIO="native"
     QEMU_HAS_LBAF_MASK=0
     QEMU_HAS_PCI_MMIO_BRIDGE=0
@@ -206,6 +207,9 @@ function qemu_probe_caps {
     nvme_ns_help=$("${qemu}" -device nvme-ns,help 2>&1) || true
     echo "${nvme_ns_help}" | grep -q "lbaf-mask=" \
         && QEMU_HAS_LBAF_MASK=1
+    if [ -n "${aio_override}" ]; then
+        QEMU_AIO="${aio_override}"
+    fi
     return 0
 }
 

--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -181,7 +181,7 @@ function qemu_probe_caps {
     QEMU_HAS_IOEVENTFD=0
     QEMU_HAS_DBCS=0
     local aio_override="${QEMU_AIO:-}"
-    QEMU_AIO="native"
+    QEMU_AIO="threads"
     QEMU_HAS_LBAF_MASK=0
     QEMU_HAS_PCI_MMIO_BRIDGE=0
     QEMU_CAPS_PROBED=1
@@ -194,7 +194,6 @@ function qemu_probe_caps {
                 "binary." >&2
             exit 1
         fi
-        QEMU_AIO="threads"
         QEMU_CAPS_PROBED=0
         return 0
     fi
@@ -207,13 +206,20 @@ function qemu_probe_caps {
         && QEMU_HAS_IOEVENTFD=1
     echo "${nvme_help}" | grep -q "dbcs=" \
         && QEMU_HAS_DBCS=1
-    if echo quit | timeout 2 "${qemu}" \
-           -machine none -monitor stdio \
-           -drive driver=null-co,if=none,id=t \
-           -drive driver=null-co,if=none,id=u,aio=io_uring \
-           >/dev/null 2>&1; then
-        QEMU_AIO="io_uring"
+    local probe_img probe_aio
+    probe_img=$(mktemp /tmp/qemu-aio-probe.XXXXXX.qcow2)
+    if qemu-img create -f qcow2 "${probe_img}" 1M >/dev/null 2>&1; then
+        for probe_aio in io_uring native threads; do
+            if echo quit | timeout 2 "${qemu}" \
+                   -machine none -monitor stdio \
+                   -drive file="${probe_img}",format=qcow2,if=none,id=t,aio=${probe_aio} \
+                   >/dev/null 2>&1; then
+                QEMU_AIO="${probe_aio}"
+                break
+            fi
+        done
     fi
+    rm -f "${probe_img}"
     local nvme_ns_help
     nvme_ns_help=$("${qemu}" -device nvme-ns,help 2>&1) || true
     echo "${nvme_ns_help}" | grep -q "lbaf-mask=" \
@@ -259,9 +265,19 @@ function nvme_create {
     echo "${drv} ${dev} ${ns} "
 }
 
+function pci_sys_bdf () {
+    if [[ ${1} =~ ^[0-9a-fA-F]{4}: ]]; then
+        echo "${1}"
+    else
+        echo "0000:${1}"
+    fi
+}
+
   # Check that the user has provided valid PCIe bus addresses and also check
   # that the devices associated with these addresses are bound to vfio-pci
 function pci_check () {
+    local sysbdf vfio_group vfio_dev
+
     if [[ ! ${1} =~ ^([0-9a-fA-F]{4}:)?[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-9]$ ]]; then
         echo "ERROR: PCIe bus address is invalid (${1})."
         exit 1
@@ -270,6 +286,21 @@ function pci_check () {
     if ! lspci -k -s "${1}" | grep -q "vfio-pci"; then
         echo "ERROR: Device ${1} is not bound to vfio-pci driver."
         exit 1
+    fi
+
+    sysbdf=$(pci_sys_bdf "${1}")
+    if [ -e "/sys/bus/pci/devices/${sysbdf}/iommu_group" ]; then
+        vfio_group=$(basename "$(readlink -f \
+            "/sys/bus/pci/devices/${sysbdf}/iommu_group")")
+        vfio_dev="/dev/vfio/${vfio_group}"
+        if [ ! -r "${vfio_dev}" ] || [ ! -w "${vfio_dev}" ]; then
+            echo "ERROR: Cannot access ${vfio_dev} (IOMMU group for ${1})."
+            ls -l "${vfio_dev}" 2>/dev/null \
+                || echo "       ${vfio_dev} does not exist."
+            echo "       Fix: sudo chmod 660 ${vfio_dev}"
+            echo "       Persistent: ../udev/install-vfio-rules"
+            exit 1
+        fi
     fi
 }
 

--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -108,6 +108,14 @@
 # must still have its own overlay (different VM_NAME).
 # Use gen-vm with BACKING_FILE to create per-VM overlays
 # from a shared backing image.
+#
+# EXTRA_HOSTFWD appends additional host-forward rules to
+# the user-mode netdev.  The value is spliced directly
+# after the SSH forward, so it must start with a comma.
+# Example: EXTRA_HOSTFWD=",hostfwd=tcp::9150-:9100"
+# forwards host port 9150 to guest port 9100.  Multiple
+# forwards can be chained:
+#   EXTRA_HOSTFWD=",hostfwd=tcp::9150-:9100,hostfwd=tcp::8080-:80"
 
 set -e
 
@@ -136,6 +144,7 @@ MCAST_GROUP=${MCAST_GROUP:-none}
 QMP_SOCKET=${QMP_SOCKET:-false}
 QEMU_GUEST_AGENT=${QEMU_GUEST_AGENT:-enable}
 BACKING_SHARED=${BACKING_SHARED:-false}
+EXTRA_HOSTFWD=${EXTRA_HOSTFWD:-}
 
 if [ "${KVM}" = "enable" ]; then
     KVM=",accel=kvm"
@@ -444,7 +453,7 @@ QEMU_CMD=(${QEMU_PATH}qemu-system-${QARCH}
    "${PCI_MMIO_BRIDGE_ARGS[@]}"
    "${VFIO_USERDEV_ARGS[@]}"
    ${ROOT_DRIVE}
-   -netdev user,id=net0,hostfwd=tcp::${SSH_PORT}-:22
+   -netdev user,id=net0,hostfwd=tcp::${SSH_PORT}-:22${EXTRA_HOSTFWD}
    -device virtio-net-pci,netdev=net0
    ${DATA_NIC_ARGS}
    ${MCAST_ARGS}

--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -146,6 +146,18 @@ QEMU_GUEST_AGENT=${QEMU_GUEST_AGENT:-enable}
 BACKING_SHARED=${BACKING_SHARED:-false}
 EXTRA_HOSTFWD=${EXTRA_HOSTFWD:-}
 
+if [ -n "${EXTRA_HOSTFWD}" ]; then
+    if [[ ${EXTRA_HOSTFWD} != ,* ]]; then
+        echo "Error: EXTRA_HOSTFWD must start with a comma" >&2
+        echo "       Example: EXTRA_HOSTFWD=\",hostfwd=tcp::9150-:9100\"" >&2
+        exit 1
+    fi
+    if [[ ${EXTRA_HOSTFWD} =~ [[:space:]] ]]; then
+        echo "Error: EXTRA_HOSTFWD must not contain whitespace." >&2
+        exit 1
+    fi
+fi
+
 if [ "${KVM}" = "enable" ]; then
     KVM=",accel=kvm"
 else

--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -74,9 +74,11 @@
 #     /tmp/qmp-${VM_NAME}-${SSH_PORT}.sock
 #   - Any other value is treated as a custom socket path
 #
-# QGA_SOCKET_PATH controls the host-side UNIX socket path for the
-# QEMU Guest Agent channel. By default, this is:
-#   /tmp/qga-${VM_NAME}-${SSH_PORT}.sock
+# QEMU_GUEST_AGENT (amd64 only) exposes the virtio-serial port
+# org.qemu.guest_agent.0 so qemu-guest-agent can run in the guest.
+#   - "enable" (default): virtio-serial-pci plus chardev socket at
+#     /tmp/qga-${VM_NAME}-${SSH_PORT}.sock (server=on,wait=off)
+#   - "none": omit guest-agent devices (legacy run-vm behavior)
 #
 # DATA_NIC_QUEUES adds a second multi-queue virtio-net NIC backed
 # by a TAP device (named dt<SSH_PORT>, e.g. dt2231).  This is
@@ -132,8 +134,8 @@ DATA_NIC_QUEUES=${DATA_NIC_QUEUES:-0}
 DRY_RUN=${DRY_RUN:-none}
 MCAST_GROUP=${MCAST_GROUP:-none}
 QMP_SOCKET=${QMP_SOCKET:-false}
+QEMU_GUEST_AGENT=${QEMU_GUEST_AGENT:-enable}
 BACKING_SHARED=${BACKING_SHARED:-false}
-QGA_SOCKET_PATH=${QGA_SOCKET_PATH:-/tmp/qga-${VM_NAME}-${SSH_PORT}.sock}
 
 if [ "${KVM}" = "enable" ]; then
     KVM=",accel=kvm"
@@ -413,11 +415,15 @@ if [ "${QMP_SOCKET}" != "false" ]; then
     QMP_ARGS="-qmp unix:${QMP_SOCKET_PATH},server,nowait"
 fi
 
-QGA_ARGS=(
-    -chardev "socket,path=${QGA_SOCKET_PATH},server=on,wait=off,id=qga0"
-    -device virtio-serial
-    -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0
-)
+GUEST_AGENT_ARGS=()
+if [ "${ARCH}" = "amd64" ] && [ "${QEMU_GUEST_AGENT}" != "none" ]; then
+    QGA_SOCK="/tmp/qga-${VM_NAME}-${SSH_PORT}.sock"
+    GUEST_AGENT_ARGS=(
+        -chardev socket,id=qga0,path="${QGA_SOCK}",server=on,wait=off
+        -device virtio-serial-pci,id=virtio-serial0
+        -device virtserialport,chardev=qga0,bus=virtio-serial0.0,name=org.qemu.guest_agent.0
+    )
+fi
 
 ROOT_DRIVE="-drive if=virtio,format=qcow2"
 ROOT_DRIVE+=",file=${IMAGES}/${VM_NAME}.qcow2"
@@ -442,11 +448,14 @@ QEMU_CMD=(${QEMU_PATH}qemu-system-${QARCH}
    -device virtio-net-pci,netdev=net0
    ${DATA_NIC_ARGS}
    ${MCAST_ARGS}
-   ${QMP_ARGS}
-   "${QGA_ARGS[@]}")
+   "${GUEST_AGENT_ARGS[@]}"
+   ${QMP_ARGS})
 
 if [ "${DRY_RUN}" != "none" ]; then
     echo "${QEMU_CMD[@]}"
 else
+    if [ "${ARCH}" = "amd64" ] && [ "${QEMU_GUEST_AGENT}" != "none" ]; then
+        rm -f "/tmp/qga-${VM_NAME}-${SSH_PORT}.sock"
+    fi
     "${QEMU_CMD[@]}"
 fi

--- a/udev/99-qemu-minimal-vfio.rules
+++ b/udev/99-qemu-minimal-vfio.rules
@@ -1,0 +1,14 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Grant members of the kvm group read/write access to VFIO character
+# devices so unprivileged QEMU can open IOMMU groups for PCI passthrough.
+#
+# Install: udev/install-vfio-rules
+
+# IOMMU group nodes (/dev/vfio/N) opened by qemu -device vfio-pci
+SUBSYSTEM=="vfio", KERNEL=="[0-9]*", GROUP="kvm", MODE="0660"
+
+# Per-device nodes (/dev/vfio/devices/vfioN) on kernels with vfio-dev
+SUBSYSTEM=="vfio-dev", KERNEL=="vfio[0-9]*", GROUP="kvm", MODE="0660"

--- a/udev/install-vfio-rules
+++ b/udev/install-vfio-rules
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# install-vfio-rules
+#
+# (C) Stephen Bates <sbates@raithlin>
+#
+# Install udev rules that grant the kvm group access to VFIO
+# character devices (/dev/vfio/N and /dev/vfio/devices/vfioN).
+# Required for PCI_HOSTDEV passthrough via run-vm without root.
+
+set -e
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+RULE_SRC="${SCRIPT_DIR}/99-qemu-minimal-vfio.rules"
+RULE_DST="/etc/udev/rules.d/99-qemu-minimal-vfio.rules"
+
+if [ ! -f "${RULE_SRC}" ]; then
+    echo "ERROR: Missing ${RULE_SRC}" >&2
+    exit 1
+fi
+
+sudo install -m 0644 "${RULE_SRC}" "${RULE_DST}"
+sudo udevadm control --reload-rules
+sudo udevadm trigger --subsystem-match=vfio
+sudo udevadm trigger --subsystem-match=vfio-dev
+
+echo "Installed ${RULE_DST}"
+echo "Users must be in the kvm group (and re-login) for access."


### PR DESCRIPTION
## Summary

This series hardens `run-vm` for mixed passthrough topologies and
restores predictable control over disk I/O and guest-agent wiring.
It replaces the always-on QGA setup from PR #101 with an amd64-only
`QEMU_GUEST_AGENT` toggle, adds optional extra user-mode port
forwards, and extends smoke-test coverage for the new behavior.

- **Honor `QEMU_AIO` override** — Save the user-supplied value before
  `qemu_probe_caps` auto-detects native/io_uring support, then restore
  it when explicitly set. Previously an explicit `QEMU_AIO` was always
  replaced by the probed default.
- **Sequential PCIe root-port chassis IDs** — Assign a shared,
  monotonically increasing `chassis=` to each `pcie-root-port` created
  for `PCI_HOSTDEV` and `VFIO_USERDEV`. Avoids ambiguous topology when
  multiple passthrough devices or mixed VFIO / vfio-user endpoints are
  present.
- **Conditional guest agent on amd64** — Replace unconditional QGA
  devices with `QEMU_GUEST_AGENT` (`enable` default, `none` for legacy).
  Use `virtio-serial-pci` with an explicit bus, remove stale QGA sockets
  before launch, and drop the separate `QGA_SOCKET_PATH` knob in favor
  of the fixed `/tmp/qga-${VM_NAME}-${SSH_PORT}.sock` path.
- **`EXTRA_HOSTFWD` for user-mode netdev** — Append comma-prefixed
  `hostfwd=` rules after the default SSH forward, e.g.
  `EXTRA_HOSTFWD=",hostfwd=tcp::9150-:9100"`.
- **Docs and CI** — Document `QEMU_GUEST_AGENT` and `EXTRA_HOSTFWD` in
  README; extend smoke-test dry-runs to assert `virtio-serial-pci`,
  guest-agent omission when `QEMU_GUEST_AGENT=none`, and custom
  hostfwd rules.

## Test plan

- [ ] `DRY_RUN=1 ./run-vm` on amd64 — guest-agent devices present by
      default (`virtio-serial-pci`, `org.qemu.guest_agent.0`)
- [ ] `QEMU_GUEST_AGENT=none DRY_RUN=1 ./run-vm` — no guest-agent
      devices in output
- [ ] `EXTRA_HOSTFWD=",hostfwd=tcp::9150-:9100" DRY_RUN=1 ./run-vm` —
      extra forward appears on the user netdev
- [ ] With `PCI_HOSTDEV` and/or `VFIO_USERDEV` set, confirm each
      `pcie-root-port` has a unique, sequential `chassis=` value
- [ ] Set `QEMU_AIO=io_uring` (or another explicit value) and confirm
      it survives capability probing
- [ ] CI smoke-test workflow passes (dry-run checks for new env vars)