### PR TITLE
gen-vm: add optional Ansible post-setup via sbates130272.batesste

### DIFF
--- a/.github/workflows/ansible-setup-test.yml
+++ b/.github/workflows/ansible-setup-test.yml
@@ -1,0 +1,145 @@
+name: ansible-setup-test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'ansible/**'
+      - 'qemu/gen-vm'
+      - '.github/workflows/ansible-setup-test.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'ansible/**'
+      - 'qemu/gen-vm'
+      - '.github/workflows/ansible-setup-test.yml'
+
+jobs:
+
+  syntax-check:
+    name: ansible-syntax-check
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4.3.1
+    - name: Install ansible (cached)
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: ansible python3-pip
+    - name: Install sbates130272.batesste collection
+      run: ansible-galaxy collection install -r ansible/requirements.yml
+    - name: Ensure jmespath for Ansible json_query filter
+      run: |
+        py=$(sed -n '1s/^#! *//p' "$(command -v ansible-playbook)")
+        echo "Ansible controller Python: ${py} ($(${py} --version))"
+        if ! "${py}" -c 'import jmespath'; then
+          sudo apt-get update -qq
+          sudo apt-get install -y python3-pip
+          sudo "${py}" -m pip install --break-system-packages jmespath
+        fi
+        "${py}" -c 'import jmespath; print(jmespath.__file__)'
+    - name: Syntax-check vm-setup playbook
+      run: ansible-playbook --syntax-check playbooks/vm-setup.yml
+      working-directory: ansible
+
+  gen-vm-ansible-setup:
+    name: gen-vm-ansible-setup
+    needs: syntax-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4.3.1
+    - name: Install packages (cached)
+      uses: awalsh128/cache-apt-pkgs-action@v1
+      with:
+        packages: >-
+          qemu-system-x86 qemu-utils cloud-image-utils ansible
+          openssh-client python3-pip
+    - name: Generate SSH key-pair
+      run: ssh-keygen -t rsa -q -f "$HOME/.ssh/id_rsa" -N ""
+    - name: Prepare GnuPG directory for git_setup
+      run: mkdir -p "$HOME/.gnupg"
+    - name: Cache cloud image
+      uses: actions/cache@v4
+      with:
+        path: images/*-server-cloudimg-*.img
+        key: cloud-img-amd64-noble-ansible
+    - name: Ensure images directory exists
+      run: mkdir -p images
+    - name: Ensure jmespath for Ansible json_query filter
+      run: |
+        py=$(sed -n '1s/^#! *//p' "$(command -v ansible-playbook)")
+        echo "Ansible controller Python: ${py} ($(${py} --version))"
+        if ! "${py}" -c 'import jmespath'; then
+          sudo apt-get update -qq
+          sudo apt-get install -y python3-pip
+          sudo "${py}" -m pip install --break-system-packages jmespath
+        fi
+        "${py}" -c 'import jmespath; print(jmespath.__file__)'
+    - name: Generate VM with Ansible post-setup
+      run: ./gen-vm
+      working-directory: qemu
+      env:
+        VM_NAME: ansible-setup-test
+        RELEASE: noble
+        KVM: none
+        USERNAME: ubuntu
+        PASS: password
+        PACKAGES: none
+        SIZE: 8
+        ANSIBLE_SETUP: true
+        ANSIBLE_USERNAME: ubuntu
+        ANSIBLE_EXTRA_ARGS: '-e {"git_setup_enable_gpg_signing":false}'
+    - name: Boot VM as background task
+      run: ./run-vm > run-vm-output.log 2>&1 &
+      working-directory: qemu
+      env:
+        VM_NAME: ansible-setup-test
+        KVM: none
+    - name: Wait for VM to boot (180s timeout)
+      run: |
+        echo "Waiting for VM to accept SSH..."
+        timeout=180
+        elapsed=0
+        while [ $elapsed -lt $timeout ]; do
+          if ssh -o ConnectTimeout=1 \
+                 -o NoHostAuthenticationForLocalhost=yes \
+                 -o StrictHostKeyChecking=no \
+                 -p 2222 ubuntu@localhost true 2>/dev/null; then
+            echo "✓ VM ready after $elapsed seconds"
+            exit 0
+          fi
+          sleep 2
+          elapsed=$((elapsed + 2))
+        done
+        echo "✗ VM failed to boot within $timeout seconds"
+        exit 1
+    - name: Output run-vm log on failure
+      if: failure()
+      run: cat qemu/run-vm-output.log
+    - name: Verify user_setup copied SSH key
+      run: |
+        ssh -o NoHostAuthenticationForLocalhost=yes \
+          -o StrictHostKeyChecking=no \
+          -p 2222 ubuntu@localhost test -f .ssh/id_rsa
+        echo "✓ user_setup SSH key present in guest"
+    - name: Verify fave_packages installed fio
+      run: |
+        ssh -o NoHostAuthenticationForLocalhost=yes \
+          -o StrictHostKeyChecking=no \
+          -p 2222 ubuntu@localhost \
+          "dpkg-query -W -f='\${Status}' fio" \
+          | grep -q 'install ok installed'
+        echo "✓ fave_packages installed fio in guest"
+    - name: Verify git_setup configured git identity
+      run: |
+        ssh -o NoHostAuthenticationForLocalhost=yes \
+          -o StrictHostKeyChecking=no \
+          -p 2222 ubuntu@localhost \
+          git config --global user.name \
+          | grep -q 'Stephen Bates'
+        echo "✓ git_setup configured git user.name in guest"

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,4 +1,5 @@
 Ansible
+ARGS
 Bjorling's
 Busybox
 CMB
@@ -120,6 +121,7 @@ initrd
 intel
 intresting
 jessie
+jmespath
 kbusch
 kickstart
 ko
@@ -176,6 +178,7 @@ seperate
 shellcheck
 snapshotted
 stackoverflow
+stebates
 sudo
 symlink
 sys
@@ -184,6 +187,7 @@ targetted
 testdev
 ttyS
 txt
+ui
 ubuntu
 udev
 uefi

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ qemu-minimal/
   packages.d/
     packages-default     Default cloud-init package set
     packages-minimal     Minimal cloud-init package set
+  ansible/
+    playbooks/vm-setup.yml  Post cloud-init Ansible playbook
+    requirements.yml        Galaxy collection requirements
   udev/
     99-qemu-minimal-vfio.rules  VFIO device permissions
     install-vfio-rules            Install the udev rules
@@ -108,6 +111,34 @@ PACKAGES=../packages.d/packages-minimal ./gen-vm
 
 Set `PACKAGES=none` to skip package installation entirely.
 
+## Ansible Post-Setup
+
+After cloud-init first boot, `gen-vm` can optionally run an
+Ansible playbook from the top-level `ansible/` directory against
+the backing image. This installs roles from the
+[sbates130272.batesste][batesste-galaxy] Galaxy collection
+(user setup, favourite packages, git configuration, and more).
+
+The host must have `ansible`, `ansible-galaxy`, and the Python
+`jmespath` module for the same interpreter as `ansible-playbook`
+(install with `python3 -m pip install --break-system-packages jmespath`
+when needed). When the collection is not already installed, `gen-vm` runs
+`ansible-galaxy collection install -r ansible/requirements.yml`.
+
+Customize the default role list in
+[`ansible/playbooks/vm-setup.yml`](ansible/playbooks/vm-setup.yml).
+
+```bash
+cd qemu
+ANSIBLE_SETUP=true \
+  ANSIBLE_USERNAME=stebates \
+  VM_NAME=base ./gen-vm
+```
+
+Ansible changes are written into the backing qcow2, so overlays
+created with `BACKING_FILE` inherit them. Ansible is skipped when
+`RESTORE_IMAGE=true` or `BACKING_FILE` is set.
+
 ## Environment Variables (gen-vm)
 
 | Variable | Default | Description |
@@ -129,6 +160,14 @@ Set `PACKAGES=none` to skip package installation entirely.
 | `NO_BACKING` | `false` | Create image without backing file |
 | `RESTORE_IMAGE` | `false` | Recreate image from existing backing file |
 | `BACKING_FILE` | (empty) | Path to existing backing qcow2 for overlay creation |
+| `ANSIBLE_SETUP` | `false` | Run Ansible post-setup after cloud-init first boot |
+| `ANSIBLE_DIR` | `../ansible` | Path to repo ansible/ directory |
+| `ANSIBLE_PLAYBOOK` | `playbooks/vm-setup.yml` | Playbook path under ANSIBLE_DIR |
+| `ANSIBLE_INVENTORY` | `inventory/qemu-vm.yml` | Inventory path under ANSIBLE_DIR |
+| `ANSIBLE_TAGS` | (empty) | Optional `--tags` filter for the playbook |
+| `ANSIBLE_EXTRA_ARGS` | (empty) | Extra arguments passed to ansible-playbook |
+| `ANSIBLE_USERNAME` | `$USERNAME` | Target account name for collection roles |
+| `ANSIBLE_TIMEOUT` | `600` | SSH wait timeout (seconds) for Ansible boot |
 
 ### RESTORE_IMAGE
 
@@ -220,3 +259,7 @@ opens internally. Both are needed to prevent lock
 conflicts across instances sharing the same backing
 file. Each VM must still use a distinct `VM_NAME` (and
 therefore a distinct overlay) to avoid data corruption.
+
+<!-- References -->
+
+[batesste-galaxy]: https://galaxy.ansible.com/ui/repo/published/sbates130272/batesste/

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+inventory = inventory/qemu-vm.yml
+collections_path = ~/.ansible/collections:/usr/share/ansible/collections
+host_key_checking = False

--- a/ansible/inventory/qemu-vm.yml
+++ b/ansible/inventory/qemu-vm.yml
@@ -1,0 +1,14 @@
+---
+all:
+  vars:
+    ansible_host: 127.0.0.1
+    ansible_port: 2222
+    ansible_user: ubuntu
+    ansible_ssh_common_args: >-
+      -o StrictHostKeyChecking=no
+      -o UserKnownHostsFile=/dev/null
+
+  children:
+    qemuvm:
+      hosts:
+        guest:

--- a/ansible/playbooks/vm-setup.yml
+++ b/ansible/playbooks/vm-setup.yml
@@ -1,0 +1,19 @@
+---
+- name: Post cloud-init VM setup
+  hosts: qemuvm
+  gather_facts: true
+  # Tasks that need root in the upstream sbates130272.batesste roles set
+  # `become: true` explicitly, so leave the default off here. Otherwise the
+  # git_setup role's `community.general.git_config` (scope: global) tasks
+  # would write to /root/.gitconfig instead of the target user's home.
+  become: false
+  vars:
+    username: "{{ vm_username | default('ubuntu') }}"
+    root_user: "{{ vm_root_user | default('ubuntu') }}"
+    user_setup_create: false
+    user_setup_vm_fstab: false
+    user_setup_motd: true
+  roles:
+    - role: sbates130272.batesste.user_setup
+    - role: sbates130272.batesste.fave_packages
+    - role: sbates130272.batesste.git_setup

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: sbates130272.batesste
+    version: ">=1.4.0"

--- a/qemu/gen-vm
+++ b/qemu/gen-vm
@@ -50,6 +50,11 @@
 # of the specified backing file. This allows multiple VMs to
 # share a single read-only backing image with per-VM diffs
 # written to their own overlays.
+#
+# ANSIBLE_SETUP when true runs a host-side Ansible playbook
+# (from ../ansible by default) against the backing image after
+# cloud-init first boot. The sbates130272.batesste collection
+# is installed from Galaxy when not already present on the host.
 
 QEMU_PATH=${QEMU_PATH:-}
 VM_NAME=${VM_NAME:-qemu-minimal}
@@ -70,6 +75,14 @@ FORCE=${FORCE:-false}
 NO_BACKING=${NO_BACKING:-false}
 RESTORE_IMAGE=${RESTORE_IMAGE:-false}
 BACKING_FILE=${BACKING_FILE:-}
+ANSIBLE_SETUP=${ANSIBLE_SETUP:-false}
+ANSIBLE_DIR=${ANSIBLE_DIR:-../ansible}
+ANSIBLE_PLAYBOOK=${ANSIBLE_PLAYBOOK:-playbooks/vm-setup.yml}
+ANSIBLE_INVENTORY=${ANSIBLE_INVENTORY:-inventory/qemu-vm.yml}
+ANSIBLE_TAGS=${ANSIBLE_TAGS:-}
+ANSIBLE_EXTRA_ARGS=${ANSIBLE_EXTRA_ARGS:-}
+ANSIBLE_USERNAME=${ANSIBLE_USERNAME:-${USERNAME}}
+ANSIBLE_TIMEOUT=${ANSIBLE_TIMEOUT:-600}
 
   # Focal and above prefers us to use cloud images and
   # cloud-init. Download the focal cloud image and set it up using a
@@ -77,6 +90,11 @@ BACKING_FILE=${BACKING_FILE:-}
   # access.
 
 set -e
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+if [[ "${ANSIBLE_DIR}" != /* ]]; then
+    ANSIBLE_DIR="${SCRIPT_DIR}/${ANSIBLE_DIR}"
+fi
 
 # Accept both codenames (e.g. noble) and versions (e.g. 26.04).
 resolve_cloud_image_info() {
@@ -112,6 +130,198 @@ create_image_with_backing() {
             touch -t $(date -j -f "%Y-%m-%d %H:%M:%S" \
                 "${backing_timestamp}" +%Y%m%d%H%M.%S 2>/dev/null) ${2}
     fi
+}
+
+# QEMU nographic can leave stdio non-blocking; Ansible 7+ requires blocking IO.
+restore_blocking_stdio() {
+    python3 -c 'import os, sys
+for handle in (sys.stdin, sys.stdout, sys.stderr):
+    try:
+        os.set_blocking(handle.fileno(), True)
+    except Exception:
+        pass' 2>/dev/null || true
+}
+
+ensure_ansible_collection() {
+    restore_blocking_stdio
+    if ansible-galaxy collection list 2>/dev/null \
+        | grep -qE '^sbates130272\.batesste[[:space:]]'; then
+        return 0
+    fi
+    echo "Installing sbates130272.batesste collection from Galaxy..."
+    restore_blocking_stdio
+    ansible-galaxy collection install \
+        -r "${ANSIBLE_DIR}/requirements.yml"
+}
+
+ansible_controller_python() {
+    local ap py
+
+    ap=$(command -v ansible-playbook 2>/dev/null) || true
+    if [ -n "${ap}" ] && [ -r "${ap}" ]; then
+        py=$(sed -n '1s/^#! *//p' "${ap}")
+        if [ -n "${py}" ] && [ -x "${py}" ]; then
+            echo "${py}"
+            return 0
+        fi
+    fi
+    command -v python3
+}
+
+ensure_jmespath() {
+    local py pip_flag
+
+    py=$(ansible_controller_python)
+    if [ -z "${py}" ]; then
+        echo "Error: cannot determine Ansible controller Python!"
+        exit 1
+    fi
+    if "${py}" -c 'import jmespath' 2>/dev/null; then
+        return 0
+    fi
+    for pip_flag in --break-system-packages --user; do
+        if "${py}" -m pip install "${pip_flag}" jmespath >/dev/null 2>&1 \
+            && "${py}" -c 'import jmespath' 2>/dev/null; then
+            echo "Installed jmespath via pip (${pip_flag})."
+            return 0
+        fi
+    done
+    echo "Error: ${py} cannot import jmespath, which is required on" \
+         "the Ansible controller for sbates130272.batesste roles."
+    echo "Install with: ${py} -m pip install --break-system-packages jmespath"
+    echo "           or: sudo apt install python3-pip &&" \
+         "${py} -m pip install --break-system-packages jmespath"
+    exit 1
+}
+
+prepare_ansible_setup() {
+    if [ "${ANSIBLE_SETUP}" != "true" ]; then
+        return 0
+    fi
+
+    if ! command -v ansible-playbook >/dev/null 2>&1; then
+        echo "Error: ansible-playbook not found" \
+             "(required for ANSIBLE_SETUP=true)!"
+        exit 1
+    fi
+    if ! command -v ansible-galaxy >/dev/null 2>&1; then
+        echo "Error: ansible-galaxy not found" \
+             "(required for ANSIBLE_SETUP=true)!"
+        exit 1
+    fi
+
+    local playbook="${ANSIBLE_PLAYBOOK}"
+    local inventory="${ANSIBLE_INVENTORY}"
+    if [ ! -f "${ANSIBLE_DIR}/${playbook}" ]; then
+        echo "Error: Ansible playbook ${ANSIBLE_DIR}/${playbook} does not exist!"
+        exit 1
+    fi
+    if [ ! -f "${ANSIBLE_DIR}/${inventory}" ]; then
+        echo "Error: Ansible inventory ${ANSIBLE_DIR}/${inventory} does not exist!"
+        exit 1
+    fi
+    if [ ! -f "${ANSIBLE_DIR}/requirements.yml" ]; then
+        echo "Error: ${ANSIBLE_DIR}/requirements.yml does not exist!"
+        exit 1
+    fi
+
+    ensure_jmespath
+    ensure_ansible_collection
+}
+
+wait_for_ssh() {
+    local timeout=${ANSIBLE_TIMEOUT}
+    local elapsed=0
+
+    echo "Waiting for VM to accept SSH on port ${SSH_PORT}..."
+    while [ "${elapsed}" -lt "${timeout}" ]; do
+        if ssh -o ConnectTimeout=1 \
+               -o StrictHostKeyChecking=no \
+               -o UserKnownHostsFile=/dev/null \
+               -p "${SSH_PORT}" "${USERNAME}@localhost" \
+               true 2>/dev/null; then
+            echo "VM ready for Ansible after ${elapsed} seconds"
+            return 0
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    echo "Error: VM did not accept SSH within ${timeout} seconds!"
+    return 1
+}
+
+stop_ansible_qemu() {
+    local pid="$1"
+    if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
+        kill "${pid}" 2>/dev/null || true
+        wait "${pid}" 2>/dev/null || true
+    fi
+}
+
+run_ansible_setup() {
+    if [ "${ANSIBLE_SETUP}" != "true" ]; then
+        return 0
+    fi
+
+    restore_blocking_stdio
+
+    echo "Booting ${IMAGES}/${VM_NAME}-backing.qcow2 for Ansible setup..."
+    ${QEMU_PATH}qemu-system-${QARCH} \
+       ${QARCH_ARGS} \
+       -smp cpus=${VCPUS} \
+       -m ${VMEM} \
+       -nographic \
+       -drive if=virtio,format=qcow2,file=${IMAGES}/${VM_NAME}-backing.qcow2 \
+       -netdev user,id=net0,hostfwd=tcp::${SSH_PORT}-:22 \
+       -device virtio-net-pci,netdev=net0 &
+    local ansible_qemu_pid=$!
+
+    if ! wait_for_ssh; then
+        stop_ansible_qemu "${ansible_qemu_pid}"
+        exit 1
+    fi
+
+    echo "Running Ansible playbook ${ANSIBLE_PLAYBOOK}..."
+    local ap_extra=()
+    if [ -n "${ANSIBLE_TAGS}" ]; then
+        ap_extra+=(--tags "${ANSIBLE_TAGS}")
+    fi
+    if [ -n "${ANSIBLE_EXTRA_ARGS}" ]; then
+        # shellcheck disable=SC2206
+        ap_extra+=(${ANSIBLE_EXTRA_ARGS})
+    fi
+
+    local playbook="${ANSIBLE_PLAYBOOK}"
+    local inventory="${ANSIBLE_INVENTORY}"
+    restore_blocking_stdio
+    ensure_jmespath
+    if ! (
+        cd "${ANSIBLE_DIR}"
+        ANSIBLE_CONFIG="${ANSIBLE_DIR}/ansible.cfg" \
+        ansible-playbook \
+            -i "${inventory}" \
+            "${playbook}" \
+            -e "ansible_port=${SSH_PORT}" \
+            -e "ansible_user=${USERNAME}" \
+            -e "vm_username=${ANSIBLE_USERNAME}" \
+            -e "vm_root_user=${USERNAME}" \
+            "${ap_extra[@]}"
+    ); then
+        stop_ansible_qemu "${ansible_qemu_pid}"
+        exit 1
+    fi
+
+    echo "Powering off VM after Ansible setup..."
+    ssh -o StrictHostKeyChecking=no \
+        -o UserKnownHostsFile=/dev/null \
+        -p "${SSH_PORT}" "${USERNAME}@localhost" \
+        sudo poweroff || true
+
+    if ! wait "${ansible_qemu_pid}"; then
+        stop_ansible_qemu "${ansible_qemu_pid}"
+        exit 1
+    fi
+    echo "Ansible post-setup complete."
 }
 
 # Handle RESTORE_IMAGE option - only perform the final
@@ -201,6 +411,8 @@ if [ ! -f "${SSH_KEY_FILE}" ]; then
      echo "SSH_KEY_FILE ${SSH_KEY_FILE} does not exist!"
      exit 1
 fi
+
+prepare_ansible_setup
 
 if [ "${PACKAGES}" != "none" ]; then
     if [ -f "${PACKAGES}" ]; then
@@ -340,6 +552,8 @@ ${QEMU_PATH}qemu-system-${QARCH} \
    -drive if=virtio,format=qcow2,file=${IMAGES}/${VM_NAME}-seed.qcow2 \
    -netdev user,id=net0 \
    -device virtio-net-pci,netdev=net0
+
+run_ansible_setup
 
 if [ "${NO_BACKING}" = "true" ]; then
     mv "${IMAGES}/${VM_NAME}-backing.qcow2" "${IMAGES}/${VM_NAME}.qcow2"


### PR DESCRIPTION
Enable baking sbates130272.batesste roles into VM backing images after cloud-init by re-booting with SSH and running a local playbook. Adds ansible/ layout, CI workflow, and ANSIBLE_* env vars on gen-vm.