### PR TITLE
ansible: add vm-rocm-setup playbook and CI syntax check

### DIFF
--- a/.github/workflows/ansible-setup-test.yml
+++ b/.github/workflows/ansible-setup-test.yml
@@ -44,6 +44,9 @@ jobs:
     - name: Syntax-check vm-setup playbook
       run: ansible-playbook --syntax-check playbooks/vm-setup.yml
       working-directory: ansible
+    - name: Syntax-check vm-rocm-setup playbook
+      run: ansible-playbook --syntax-check playbooks/vm-rocm-setup.yml
+      working-directory: ansible
 
   gen-vm-ansible-setup:
     name: gen-vm-ansible-setup

--- a/.github/workflows/ansible-setup-test.yml
+++ b/.github/workflows/ansible-setup-test.yml
@@ -33,7 +33,7 @@ jobs:
       run: ansible-galaxy collection install -r ansible/requirements.yml
     - name: Ensure jmespath for Ansible json_query filter
       run: |
-        py=$(sed -n '1s/^#! *//p' "$(command -v ansible-playbook)")
+        py=$(sed -n '1s/^#! *//p' "$(command -v ansible-playbook)" | awk '{print $1}')
         echo "Ansible controller Python: ${py} ($(${py} --version))"
         if ! "${py}" -c 'import jmespath'; then
           sudo apt-get update -qq
@@ -75,7 +75,7 @@ jobs:
       run: mkdir -p images
     - name: Ensure jmespath for Ansible json_query filter
       run: |
-        py=$(sed -n '1s/^#! *//p' "$(command -v ansible-playbook)")
+        py=$(sed -n '1s/^#! *//p' "$(command -v ansible-playbook)" | awk '{print $1}')
         echo "Ansible controller Python: ${py} ($(${py} --version))"
         if ! "${py}" -c 'import jmespath'; then
           sudo apt-get update -qq

--- a/ansible/playbooks/vm-rocm-setup.yml
+++ b/ansible/playbooks/vm-rocm-setup.yml
@@ -1,0 +1,26 @@
+---
+- name: Post cloud-init VM setup with ROCm and hipFile
+  hosts: qemuvm
+  gather_facts: true
+  become: false
+  vars:
+    username: "{{ vm_username | default('ubuntu') }}"
+    root_user: "{{ vm_root_user | default('ubuntu') }}"
+    user_setup_create: false
+    user_setup_vm_fstab: true
+    user_setup_motd: true
+    rocm_setup_user: "{{ vm_username | default('ubuntu') }}"
+    rocm_setup_skip_reboot: false
+    rocm_setup_run_checks: false
+    rocm_setup_install_metrics_exporter: false
+    rocm_xio_setup_run_basic_checks: false
+    rocm_xio_setup_check_rocminfo: false
+    rocm_xio_setup_run_unit_tests: false
+    rocm_xio_setup_run_test_endpoint: false
+  roles:
+    - role: sbates130272.batesste.user_setup
+    - role: sbates130272.batesste.fave_packages
+    - role: sbates130272.batesste.git_setup
+    - role: sbates130272.batesste.rocm_setup
+    - role: sbates130272.batesste.rocm_hipfile_setup
+    - role: sbates130272.batesste.rocm_xio_setup

--- a/ansible/playbooks/vm-setup.yml
+++ b/ansible/playbooks/vm-setup.yml
@@ -11,7 +11,7 @@
     username: "{{ vm_username | default('ubuntu') }}"
     root_user: "{{ vm_root_user | default('ubuntu') }}"
     user_setup_create: false
-    user_setup_vm_fstab: true
+    user_setup_vm_fstab: false
     user_setup_motd: true
   roles:
     - role: sbates130272.batesste.user_setup

--- a/ansible/playbooks/vm-setup.yml
+++ b/ansible/playbooks/vm-setup.yml
@@ -11,7 +11,7 @@
     username: "{{ vm_username | default('ubuntu') }}"
     root_user: "{{ vm_root_user | default('ubuntu') }}"
     user_setup_create: false
-    user_setup_vm_fstab: false
+    user_setup_vm_fstab: true
     user_setup_motd: true
   roles:
     - role: sbates130272.batesste.user_setup


### PR DESCRIPTION
Add ansible/playbooks/vm-rocm-setup.yml, a new playbook that extends the base vm-setup roles (user_setup, fave_packages, git_setup) with three ROCm-focused roles from the sbates130272.batesste collection:

  - rocm_setup: installs ROCm and the AMDGPU driver stack
  - rocm_hipfile_setup: builds and installs hipFile and a hipFile-enabled fio
  - rocm_xio_setup: clones and builds ROCm XIO (GPU direct storage)

Runtime checks and the metrics exporter are disabled by default so the playbook is safe to run against VMs without GPU passthrough; set rocm_setup_run_checks, rocm_xio_setup_run_basic_checks, etc. to true when a GPU is present.

Also enable user_setup_vm_fstab in vm-setup.yml and add a syntax-check step for the new playbook in the existing ansible-setup-test CI job. The ROCm install is too large to run end-to-end in CI, so syntax-check only is intentional here.