### PR TITLE
Add new QEMU arguments for NVMe P2P VRAM target

### DIFF
--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -116,6 +116,13 @@
 # forwards host port 9150 to guest port 9100.  Multiple
 # forwards can be chained:
 #   EXTRA_HOSTFWD=",hostfwd=tcp::9150-:9100,hostfwd=tcp::8080-:80"
+#
+# VRAM_DEV_INDEX selects which PCI_HOSTDEV entry (1-based) the emulated
+# NVMe controller(s) should treat as the source/sink for peer-to-peer DMA
+# via the "vram-dev" / "vram-bar" properties on -device nvme. Default
+# "none" disables the feature
+# VRAM_BAR picks the BAR index on that device (0 = BAR0, typically the
+# VRAM aperture on AMD GPUs).
 
 set -e
 
@@ -135,6 +142,8 @@ NVME_LBAF_MASK=${NVME_LBAF_MASK:-none}
 NVME_RECREATE=${NVME_RECREATE:-false}
 PCI_TESTDEV=${PCI_TESTDEV:-none}
 PCI_HOSTDEV=${PCI_HOSTDEV:-none}
+VRAM_DEV_INDEX=${VRAM_DEV_INDEX:-none}
+VRAM_BAR=${VRAM_BAR:-0}
 VFIO_USERDEV=${VFIO_USERDEV:-none}
 NVME_SIZE=1024G
 PCI_MMIO_BRIDGE=${PCI_MMIO_BRIDGE:-none}
@@ -196,6 +205,7 @@ function qemu_probe_caps {
     QEMU_AIO="threads"
     QEMU_HAS_LBAF_MASK=0
     QEMU_HAS_PCI_MMIO_BRIDGE=0
+    QEMU_HAS_VRAM_DEV=0
     QEMU_CAPS_PROBED=1
     if ! command -v "${qemu}" &>/dev/null; then
         if [ "${DRY_RUN}" = "none" ]; then
@@ -218,6 +228,8 @@ function qemu_probe_caps {
         && QEMU_HAS_IOEVENTFD=1
     echo "${nvme_help}" | grep -q "dbcs=" \
         && QEMU_HAS_DBCS=1
+    echo "${nvme_help}" | grep -q "vram-dev=" \
+        && QEMU_HAS_VRAM_DEV=1
     local probe_img probe_aio
     probe_img=$(mktemp /tmp/qemu-aio-probe.XXXXXX.qcow2)
     if qemu-img create -f qcow2 "${probe_img}" 1M >/dev/null 2>&1; then
@@ -262,6 +274,11 @@ function nvme_create {
             && dev+=",ioeventfd=off"
         [ ${QEMU_HAS_DBCS} -eq 1 ] \
             && dev+=",dbcs=off"
+    fi
+    # Wire the emulated NVMe to a VFIO passthrough device's BAR so peer-to-peer
+    # DMA (e.g. NVMe <-> GPU VRAM) resolves to the right MemoryRegion.
+    if [ "${VRAM_DEV_INDEX}" != "none" ] && [ ${QEMU_HAS_VRAM_DEV} -eq 1 ]; then
+        dev+=",vram-dev=vfio-host${VRAM_DEV_INDEX},vram-bar=${VRAM_BAR}"
     fi
     local ns="-device nvme-ns,drive=nvme-${3},bus=nvme-${3}-dev,nsid=1"
     if [ "${NVME_LBAF_MASK}" != "none" ]; then
@@ -367,7 +384,7 @@ else
         PCIE_ROOT_PORT_CHASSIS=$((PCIE_ROOT_PORT_CHASSIS + 1))
         pci_check "${THIS_PCI_HOSTDEV}"
         PCI_HOSTDEV_ARGS+="-device pcie-root-port,id=pcie.${i},chassis=${PCIE_ROOT_PORT_CHASSIS} "
-        PCI_HOSTDEV_ARGS+="-device vfio-pci,bus=pcie.${i},host=${THIS_PCI_HOSTDEV} "
+        PCI_HOSTDEV_ARGS+="-device vfio-pci,id=vfio-host${i},bus=pcie.${i},host=${THIS_PCI_HOSTDEV} "
     done
 fi
 
@@ -490,9 +507,9 @@ QEMU_CMD=(${QEMU_PATH}qemu-system-${QARCH}
    -m ${VMEM}
    ${FILESYSTEM_ARGS}
    -nographic
-   ${NVME_ARGS}
    ${PCI_TESTDEV_ARGS}
    ${PCI_HOSTDEV_ARGS}
+   ${NVME_ARGS}
    "${PCI_MMIO_BRIDGE_ARGS[@]}"
    "${VFIO_USERDEV_ARGS[@]}"
    ${ROOT_DRIVE}

--- a/qemu/run-vm
+++ b/qemu/run-vm
@@ -278,6 +278,26 @@ function nvme_create {
     # Wire the emulated NVMe to a VFIO passthrough device's BAR so peer-to-peer
     # DMA (e.g. NVMe <-> GPU VRAM) resolves to the right MemoryRegion.
     if [ "${VRAM_DEV_INDEX}" != "none" ] && [ ${QEMU_HAS_VRAM_DEV} -eq 1 ]; then
+        if [[ ! ${VRAM_DEV_INDEX} =~ ^[0-9]+$ ]] || [ "${VRAM_DEV_INDEX}" -lt 1 ]; then
+            echo "Error: VRAM_DEV_INDEX ('${VRAM_DEV_INDEX}') must be a 1-based integer index into PCI_HOSTDEV." >&2
+            exit 1
+        fi
+        if [[ ! ${VRAM_BAR} =~ ^[0-9]+$ ]]; then
+            echo "Error: VRAM_BAR ('${VRAM_BAR}') must be a non-negative integer BAR index." >&2
+            exit 1
+        fi
+        if [ "${PCI_HOSTDEV}" = "none" ]; then
+            echo "Error: VRAM_DEV_INDEX set, but PCI_HOSTDEV is 'none'." >&2
+            exit 1
+        fi
+        local hostdev_count=0 _bdf
+        for _bdf in ${PCI_HOSTDEV//,/ }; do
+            hostdev_count=$((hostdev_count + 1))
+        done
+        if [ "${VRAM_DEV_INDEX}" -gt "${hostdev_count}" ]; then
+            echo "Error: VRAM_DEV_INDEX (${VRAM_DEV_INDEX}) exceeds number of PCI_HOSTDEV entries (${hostdev_count})." >&2
+            exit 1
+        fi
         dev+=",vram-dev=vfio-host${VRAM_DEV_INDEX},vram-bar=${VRAM_BAR}"
     fi
     local ns="-device nvme-ns,drive=nvme-${3},bus=nvme-${3}-dev,nsid=1"


### PR DESCRIPTION
This adds new arguments to the QEMU invokation corresponding to these changes:
https://github.com/sbates130272/qemu/commit/cf0befc4a4cb10a01cccc81cff2b7af3586e0482
https://github.com/sbates130272/qemu/commit/59e8f40a35810072be3bff96db4217e1fe05dc6d

We probe the available QEMU arguments and gate these arguments to be passed only when available in the version of QEMU that will be used.

You have to pass in arguments specifying which BDF contains the VRAM that you are targeting and the BAR that VRAM resides in, you can do this using the following steps:
1) We already pass the BDF of the passed-through GPU to QEMU using `PCI_HOSTDEV=<BDF of GPU>,<BDF of NVMe>,...`. Consider that list of BDFs to be 1-indexed and use that index as the argument of `VRAM_DEV_INDEX`.
2) I think that `VRAM_BAR` should always be zero. This is the index of your device's BARs that corresponds to VRAM. You can check the different BARS your device exposes using a similar command to the following:
```
johtyler@cgy-decidueye:~/code$  lspci -vvv -s 0000:0c:00.0
\0c:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Navi 21 [Radeon RX 6800/6800 XT / 6900 XT] (rev c0) (prog-if 00 [VGA controller])
        Subsystem: XFX Limited Speedster MERC 319 AMD Radeon RX 6900 XT Black
        Control: I/O+ Mem+ BusMaster- SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx-
        Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
        Interrupt: pin A routed to IRQ 42
        IOMMU group: 27
        Region 0: Memory at f800000000 (64-bit, prefetchable) [size=16G]
        Region 2: Memory at fc00000000 (64-bit, prefetchable) [size=256M]
        Region 4: I/O ports at e000 [size=256]
        Region 5: Memory at fcc00000 (32-bit, non-prefetchable) [size=1M]
        Expansion ROM at fcd00000 [disabled] [size=128K]
        Capabilities: <access denied>
        Kernel driver in use: vfio-pci
        Kernel modules: amdgpu

```
The largest "Memory at" region is your VRAM. The order/indices that they appear from the `lspci` command exactly matches how QEMU indexes them. You can also find the indices with `cat /sys/bus/pci/devices/<BDF>/resource`