### PR TITLE
ci: add v1.0.0 release workflow with pip wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,20 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4.3.1
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build wheel
+        run: |
+          pip install build
+          python -m build qemu/ --wheel --outdir dist/
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2.3.2
         with:
           generate_release_notes: true
           draft: false
           prerelease: false
+          files: dist/*.whl

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Last Commit](https://img.shields.io/github/last-commit/sbates130272/qemu-minimal?style=flat-square)](https://github.com/sbates130272/qemu-minimal/commits/main)
 [![Platform](https://img.shields.io/badge/platform-x86__64%20%7C%20ARM64%20%7C%20RISC--V-blue?style=flat-square)](https://github.com/sbates130272/qemu-minimal)
 [![Ubuntu](https://img.shields.io/badge/Ubuntu-Noble%20%7C%20Resolute-orange?style=flat-square&logo=ubuntu)](https://releases.ubuntu.com/noble/)
+[![GitHub Release](https://img.shields.io/github/v/release/sbates130272/qemu-minimal?style=flat-square)](https://github.com/sbates130272/qemu-minimal/releases/latest)
 
 ## Summary
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: sbates130272.batesste
-    version: ">=2.1.1"
+    version: ">=2.1.2"

--- a/qemu/pyproject.toml
+++ b/qemu/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qemu-tool"
-version = "0.1.0"
+version = "1.0.0"
 description = "CLI tool for running and generating QEMU VMs"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/qemu/qemu-tool/__init__.py
+++ b/qemu/qemu-tool/__init__.py
@@ -1,1 +1,6 @@
-__version__ = "0.1.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("qemu-tool")
+except PackageNotFoundError:
+    __version__ = "unknown"


### PR DESCRIPTION
- Extend release.yml to build qemu-tool wheel and attach it as a release artifact on v* tag pushes
- Single-source package version via importlib.metadata in __init__.py
- Bump pyproject.toml version to 1.0.0
- Add GitHub release badge to README