### PR TITLE
feat: add --ansible-only, --ca-cert, ROCm VM playbook updates for v1.1.0

### DIFF
--- a/.github/workflows/ansible-setup-test.yml
+++ b/.github/workflows/ansible-setup-test.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install ansible
       run: apt-get update -qq && apt-get install -y -qq ansible python3-pip
     - name: Install sbates130272.batesste collection
-      run: ansible-galaxy collection install -r ansible/requirements.yml
+      run: ansible-galaxy collection install --pre -r ansible/requirements.yml
     - name: Syntax-check vm-setup playbook
       run: ansible-playbook --syntax-check playbooks/vm-setup.yml
       working-directory: ansible

--- a/ansible/playbooks/vm-rocm-setup.yml
+++ b/ansible/playbooks/vm-rocm-setup.yml
@@ -6,22 +6,17 @@
   vars:
     username: "{{ vm_username | default('ubuntu') }}"
     root_user: "{{ vm_root_user | default('ubuntu') }}"
-    user_setup_vm_fstab: false
     user_setup_motd: true
-    user_setup_dotfiles_enable: true
+    user_setup_install_amd_ca: true
     rocm_setup_user: "{{ vm_username | default('ubuntu') }}"
     rocm_setup_repo_stream: therock
     rocm_setup_skip_reboot: false
     rocm_setup_run_checks: false
     rocm_setup_install_metrics_exporter: false
-    rocm_xio_setup_run_basic_checks: false
-    rocm_xio_setup_check_rocminfo: false
-    rocm_xio_setup_run_unit_tests: false
-    rocm_xio_setup_run_test_endpoint: false
+    rocm_setup_extra_kernel_packages:
+      - linux-generic-hwe-24.04
   roles:
     - role: sbates130272.batesste.user_setup
     - role: sbates130272.batesste.fave_packages
     - role: sbates130272.batesste.git_setup
     - role: sbates130272.batesste.rocm_setup
-    - role: sbates130272.batesste.rocm_hipfile_setup
-    - role: sbates130272.batesste.rocm_xio_setup

--- a/ansible/playbooks/vm-setup.yml
+++ b/ansible/playbooks/vm-setup.yml
@@ -10,9 +10,8 @@
   vars:
     username: "{{ vm_username | default('ubuntu') }}"
     root_user: "{{ vm_root_user | default('ubuntu') }}"
-    user_setup_vm_fstab: false
     user_setup_motd: true
-    user_setup_dotfiles_enable: true
+    user_setup_install_amd_ca: true
   roles:
     - role: sbates130272.batesste.user_setup
     - role: sbates130272.batesste.fave_packages

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: sbates130272.batesste
-    version: ">=2.1.2"
+    version: ">=2.2.5"

--- a/packages.d/packages-default
+++ b/packages.d/packages-default
@@ -11,7 +11,9 @@
   - fio
   - ccache
   - gh
+  - gettext-base
   - git
+  - git-crypt
   - gnuplot
   - gpg-agent
   - libaio-dev
@@ -25,5 +27,6 @@
   - python3-pip
   - pyspelling
   - mutt
+  - stow
   - sysstat
   - tree

--- a/qemu/pyproject.toml
+++ b/qemu/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qemu-tool"
-version = "1.0.0"
+version = "1.1.0"
 description = "CLI tool for running and generating QEMU VMs"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/qemu/qemu-tool/cli.py
+++ b/qemu/qemu-tool/cli.py
@@ -148,6 +148,10 @@ def _add_gen_vm(
     p.add_argument("--restore-image", action="store_true", default=_UNSET)
     p.add_argument("--backing-file", type=Path, default=_UNSET, metavar="FILE")
     p.add_argument("--ansible-profile", type=Path, default=_UNSET, metavar="FILE")
+    p.add_argument("--ca-cert", type=Path, default=_UNSET, metavar="FILE",
+                   help="CA certificate to inject into the guest trust store.")
+    p.add_argument("--ansible-only", action="store_true", default=_UNSET,
+                   help="Skip cloud-init; re-run Ansible against an existing backing image.")
     p.set_defaults(func=_gen_vm_cmd)
 
 
@@ -273,6 +277,8 @@ def _extract_cli_overrides(
         _take("restore_image", "restore_image")
         _take("backing_file", "backing_file")
         _take("ansible_profile", "ansible_profile")
+        _take("ca_cert_file", "ca_cert")
+        _take("ansible_only", "ansible_only")
 
         raw_pkg = ns.get("packages", _UNSET)
         if raw_pkg is not _UNSET:

--- a/qemu/qemu-tool/config.py
+++ b/qemu/qemu-tool/config.py
@@ -58,3 +58,5 @@ class VMConfig:
     restore_image: bool = False
     backing_file: Path | None = None
     ansible_profile: Path | None = None
+    ca_cert_file: Path | None = None
+    ansible_only: bool = False

--- a/qemu/qemu-tool/gen_vm.py
+++ b/qemu/qemu-tool/gen_vm.py
@@ -9,6 +9,7 @@ cloud-init.
 
 from __future__ import annotations
 
+import base64
 import os
 import re
 import subprocess
@@ -43,6 +44,21 @@ def run(cfg: VMConfig) -> None:
 
     if cfg.restore_image:
         _restore_image(cfg, images)
+        return
+
+    if cfg.ansible_only:
+        if cfg.ansible_profile is None:
+            sys.exit("Error: --ansible-only requires --ansible-profile")
+        backing = images / f"{cfg.vm_name}-backing.qcow2"
+        if not backing.exists():
+            sys.exit(f"Error: --ansible-only requires an existing backing image at {backing}")
+        _prepare_ansible(cfg)
+        _run_ansible(cfg, images, backing)
+        overlay = images / f"{cfg.vm_name}.qcow2"
+        if cfg.no_backing:
+            backing.rename(overlay)
+        else:
+            _create_overlay(overlay, backing)
         return
 
     if cfg.backing_file is not None:
@@ -190,11 +206,31 @@ def _load_packages(cfg: VMConfig) -> str:
     return pkgs
 
 
+def _ca_cert_fragment(cfg: VMConfig) -> tuple[str, str]:
+    """Return (write_files_entry, runcmd_entry) for an extra CA cert, or ('', '')."""
+    if cfg.ca_cert_file is None:
+        return "", ""
+    cert_path = Path(cfg.ca_cert_file).expanduser()
+    if not cert_path.exists():
+        sys.exit(f"Error: --ca-cert file {cert_path} does not exist!")
+    cert_b64 = base64.b64encode(cert_path.read_bytes()).decode()
+    cert_name = cert_path.name
+    write_entry = f"""\
+  - path: /usr/local/share/ca-certificates/{cert_name}
+    encoding: b64
+    content: {cert_b64}
+    owner: root:root
+    permissions: '0644'"""
+    runcmd_entry = "  - update-ca-certificates"
+    return write_entry, runcmd_entry
+
+
 def _write_cloud_config(
     cfg: VMConfig, packages: str, ssh_key: Path, out: Path
 ) -> None:
     key_content = ssh_key.read_text().rstrip()
     indented_key = key_content.replace("\n", "\n      ")
+    ca_write, ca_runcmd = _ca_cert_fragment(cfg)
     out.write_text(f"""\
 #cloud-config
 hostname: {cfg.vm_name}
@@ -218,6 +254,7 @@ runcmd:
   - systemctl disable openipmi.service
   - systemctl mask openipmi.service
   - loginctl enable-linger {cfg.username}
+{ca_runcmd}
 power_state:
   delay: now
   mode: poweroff
@@ -227,6 +264,7 @@ power_state:
 timezone:
   America/Edmonton
 write_files:
+{ca_write}
   - path: /etc/sysctl.d/10-kernel-hardening.conf
     content: 'kernel.dmesg_restrict = 0'
     owner: root:root
@@ -348,7 +386,9 @@ def _parse_ansible_profile(profile: Path) -> dict[str, str]:
         line = line.strip()
         m = re.match(r'^([A-Z_]+)=\$\{[A-Z_]+:-(.+?)\}$', line)
         if m:
-            result[m.group(1)] = m.group(2).strip('"').strip("'")
+            val = m.group(2).strip('"').strip("'")
+            if not val.startswith("$"):
+                result[m.group(1)] = val
             continue
         m = re.match(r'^([A-Z_]+)=(.+)$', line)
         if m:
@@ -426,6 +466,7 @@ def _run_ansible(cfg: VMConfig, images: Path, backing: Path) -> None:
         ap_cmd = ["ansible-playbook", "-i", inventory, playbook,
                   "-e", f"ansible_port={cfg.ssh_port}",
                   "-e", f"ansible_user={cfg.username}",
+                  "-e", f"username={ansible_username}",
                   "-e", f"vm_username={ansible_username}",
                   "-e", f"vm_root_user={cfg.username}"]
         if tags:
@@ -481,16 +522,9 @@ def _wait_for_ssh(cfg: VMConfig, timeout: int) -> bool:
 
 def _ensure_ansible_collection(ansible_dir: Path) -> None:
     _restore_blocking_stdio()
-    r = subprocess.run(
-        ["ansible-galaxy", "collection", "list"],
-        capture_output=True, text=True,
-    )
-    if re.search(r"^sbates130272\.batesste\s", r.stdout, re.MULTILINE):
-        return
-    print("Installing sbates130272.batesste collection from Galaxy...")
-    _restore_blocking_stdio()
+    print("Installing/upgrading Ansible collections from requirements.yml...")
     subprocess.run(
-        ["ansible-galaxy", "collection", "install",
+        ["ansible-galaxy", "collection", "install", "--upgrade", "--pre",
          "-r", str(ansible_dir / "requirements.yml")],
         check=True,
     )


### PR DESCRIPTION
qemu-tool:
- Add --ansible-only to re-run Ansible against an existing backing image without repeating cloud-init provisioning
- Add --ca-cert to inject a CA certificate into the guest trust store via cloud-init write_files + update-ca-certificates (fixes ZScaler TLS on AMD corporate network)
- Fix _parse_ansible_profile: shell variable defaults (${VAR}) no longer stored as literal strings, fixing ANSIBLE_USERNAME resolution
- Fix _ensure_ansible_collection: always run --upgrade --pre instead of skipping when the collection is already present at a stale version
- Pass -e username= to ansible-playbook so user_setup role resolves {{ username }} correctly alongside {{ vm_username }}
- Bump qemu-tool version to 1.1.0

Ansible:
- Update sbates130272.batesste requirement to >=2.2.5
- Add --pre to ansible-galaxy install in CI and gen_vm.py
- Remove redundant user_setup_dotfiles_enable and user_setup_vm_fstab vars from both playbooks (now collection defaults)
- Add user_setup_install_amd_ca: true to both playbooks
- Replace rocm_hipfile_setup role with rocm_setup_install_hipfile (apt path)
- Add rocm_setup_extra_kernel_packages: [linux-generic-hwe-24.04]
- Remove rocm_xio_setup role (not needed for basic ROCm VM)

packages.d:
- Add gettext-base, git-crypt, stow to packages-default for dotfiles support