### PR TITLE
feat: add vm-report GitHub Pages workflow, report script, and badge

### DIFF
--- a/.github/workflows/vm-report.yml
+++ b/.github/workflows/vm-report.yml
@@ -1,0 +1,116 @@
+name: vm-report
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  generate-report:
+    name: generate-vm-report
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4.3.1
+
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | \
+          sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+
+    - name: Install packages
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq \
+          qemu-system-x86 qemu-utils cloud-image-utils python3-pip
+
+    - name: Cache pip
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: pip-qemu-tool-${{ hashFiles('qemu/pyproject.toml') }}
+
+    - name: Install qemu-tool
+      run: pip install --break-system-packages -e ./qemu
+
+    - name: Generate SSH key-pair
+      run: mkdir -p "$HOME/.ssh" && ssh-keygen -t rsa -q -f "$HOME/.ssh/id_rsa" -N ""
+
+    - name: Cache cloud image
+      uses: actions/cache@v4
+      with:
+        path: images/*-server-cloudimg-*.img
+        key: cloud-img-amd64-noble-vm-report
+
+    - name: Ensure images directory exists
+      run: mkdir -p images
+
+    - name: Generate VM
+      run: |
+        qemu-tool gen-vm \
+          --vm-name vm-report \
+          --release noble \
+          --username ubuntu \
+          --password password \
+          --packages none \
+          --size 8
+
+    - name: Boot VM
+      run: |
+        qemu-tool run-vm \
+          --vm-name vm-report \
+          --nvme 1 \
+          > run-vm-output.log 2>&1 &
+
+    - name: Wait for VM SSH (180s timeout)
+      run: |
+        elapsed=0
+        while [ $elapsed -lt 180 ]; do
+          if ssh -o ConnectTimeout=1 \
+                 -o NoHostAuthenticationForLocalhost=yes \
+                 -o StrictHostKeyChecking=no \
+                 -p 2222 ubuntu@localhost true 2>/dev/null; then
+            echo "VM ready after ${elapsed}s"
+            exit 0
+          fi
+          sleep 2; elapsed=$((elapsed + 2))
+        done
+        echo "VM failed to boot in time"
+        cat run-vm-output.log
+        exit 1
+
+    - name: Generate report
+      run: bash scripts/generate-vm-report.sh site 2222 ubuntu
+
+    - name: Show run-vm log on failure
+      if: failure()
+      run: cat run-vm-output.log
+
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: site/
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Platform](https://img.shields.io/badge/platform-x86__64%20%7C%20ARM64%20%7C%20RISC--V-blue?style=flat-square)](https://github.com/sbates130272/qemu-minimal)
 [![Ubuntu](https://img.shields.io/badge/Ubuntu-Noble%20%7C%20Resolute-orange?style=flat-square&logo=ubuntu)](https://releases.ubuntu.com/noble/)
 [![GitHub Release](https://img.shields.io/github/v/release/sbates130272/qemu-minimal?style=flat-square)](https://github.com/sbates130272/qemu-minimal/releases/latest)
+[![VM Report](https://img.shields.io/badge/VM%20Report-live-blue?style=flat-square)](https://sbates130272.github.io/qemu-minimal/)
 
 ## Summary
 

--- a/ansible/playbooks/vm-rocm-setup.yml
+++ b/ansible/playbooks/vm-rocm-setup.yml
@@ -11,8 +11,8 @@
     rocm_setup_user: "{{ vm_username | default('ubuntu') }}"
     rocm_setup_repo_stream: therock
     rocm_setup_skip_reboot: false
-    rocm_setup_run_checks: false
-    rocm_setup_install_metrics_exporter: false
+    rocm_setup_run_checks: true
+    rocm_setup_install_metrics_exporter: true
     rocm_setup_extra_kernel_packages:
       - linux-generic-hwe-24.04
   roles:

--- a/scripts/generate-vm-report.sh
+++ b/scripts/generate-vm-report.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Generate a markdown VM inspection report from a running QEMU VM.
+# Usage: generate-vm-report.sh <output-dir> [ssh-port] [ssh-user]
+set -euo pipefail
+
+OUTDIR=${1:-site}
+PORT=${2:-2222}
+USER=${3:-ubuntu}
+SSH="ssh -o NoHostAuthenticationForLocalhost=yes -o StrictHostKeyChecking=no -p ${PORT} ${USER}@localhost"
+
+TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
+COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+REPO="sbates130272/qemu-minimal"
+
+collect() { $SSH "$1" 2>/dev/null || echo "(not available)"; }
+
+KERNEL=$(collect "uname -r")
+PROC_VER=$(collect "cat /proc/version")
+CPU_INFO=$(collect "lscpu | grep -E '^CPU\(s\)|^Model name|^Thread|^Core|^Socket'")
+MEM=$(collect "free -h")
+MEM_TOTAL=$(echo "$MEM" | awk '/^Mem/{print $2}')
+MEM_FREE=$(echo "$MEM"  | awk '/^Mem/{print $4}')
+SWAP=$(echo "$MEM" | awk '/^Swap/{print $2}')
+DISK=$(collect "lsblk -o NAME,SIZE,TYPE,MOUNTPOINT")
+DF=$(collect "df -h / /boot")
+NVME=$(collect "nvme list 2>/dev/null || echo 'nvme-cli unavailable'")
+AMDGPU=$(collect "dpkg -l | grep '^ii' | grep -i amdgpu")
+ROCM_PKGS=$(collect "dpkg -l | grep '^ii' | grep '^ii  amdrocm' | awk '{print \$2, \$3}' | head -8")
+ROCM_BINS=$(collect "ls /opt/rocm/bin/ 2>/dev/null | sort")
+HIPFILE=$(collect "dpkg -l | grep '^ii' | grep -i hipfile")
+GROUPS=$(collect "groups ${USER}")
+SERVICES=$(collect "systemctl list-units --type=service --state=running --no-pager --no-legend")
+SOURCES=$(collect "ls /etc/apt/sources.list.d/")
+JOURNAL=$(collect "journalctl -p err -b --no-pager 2>/dev/null | tail -5")
+
+mkdir -p "${OUTDIR}"
+
+cat > "${OUTDIR}/_config.yml" <<'CFG'
+theme: minima
+title: qemu-minimal VM Report
+description: Live VM inspection report for the qemu-minimal project
+CFG
+
+cat > "${OUTDIR}/index.md" <<MD
+---
+title: VM Report
+---
+
+# VM Report — qemu-minimal
+
+Generated: **${TIMESTAMP}** &middot; Commit: [\`${COMMIT}\`](https://github.com/${REPO}/commit/${COMMIT})
+
+## Hardware
+
+| Resource | Value |
+|---|---|
+| CPU | $(echo "$CPU_INFO" | grep 'Model name' | sed 's/.*: *//') |
+| vCPUs | $(echo "$CPU_INFO" | grep '^CPU(s)' | awk '{print $2}') |
+| Threads/core | $(echo "$CPU_INFO" | grep 'Thread' | awk '{print $NF}') |
+| RAM | ${MEM_TOTAL} total, ${MEM_FREE} free |
+| Swap | ${SWAP} |
+
+## Kernel
+
+\`\`\`
+${KERNEL}
+\`\`\`
+
+<details><summary>Full version string</summary>
+
+\`\`\`
+${PROC_VER}
+\`\`\`
+
+</details>
+
+## Storage
+
+\`\`\`
+${DISK}
+\`\`\`
+
+### Disk usage
+
+\`\`\`
+${DF}
+\`\`\`
+
+### NVMe
+
+\`\`\`
+${NVME}
+\`\`\`
+
+## ROCm
+
+### Installed packages (sample)
+
+\`\`\`
+${ROCM_PKGS}
+\`\`\`
+
+### /opt/rocm/bin
+
+\`\`\`
+${ROCM_BINS}
+\`\`\`
+
+### hipFile
+
+\`\`\`
+${HIPFILE}
+\`\`\`
+
+## AMDGPU Kernel Driver
+
+\`\`\`
+${AMDGPU}
+\`\`\`
+
+## APT Sources
+
+\`\`\`
+${SOURCES}
+\`\`\`
+
+## User Groups
+
+\`\`\`
+${GROUPS}
+\`\`\`
+
+## Running Services
+
+\`\`\`
+${SERVICES}
+\`\`\`
+
+## System Health
+
+### Journal errors (this boot)
+
+\`\`\`
+${JOURNAL}
+\`\`\`
+MD
+
+echo "Report written to ${OUTDIR}/index.md"


### PR DESCRIPTION
- Add .github/workflows/vm-report.yml: boots a QEMU VM with KVM, SSHes in to collect system data, and deploys a markdown report to GitHub Pages; triggers on push to main, weekly on Monday at 03:00 UTC, and workflow_dispatch
- Add scripts/generate-vm-report.sh: collects kernel, CPU, memory, storage, ROCm, amdgpu-dkms, services, and journal data from a running VM via SSH and writes site/index.md + site/_config.yml
- Add VM Report shield to README.md linking to the GitHub Pages site
- Enable rocm_setup_run_checks and rocm_setup_install_metrics_exporter in vm-rocm-setup.yml now that the VM environment supports them

Note: GitHub Pages must be enabled in repo Settings with
Source: GitHub Actions before the first deployment will succeed.