### PR TITLE
fix(vm-report): escape awk field vars in heredoc to prevent bash expa…

### DIFF
--- a/scripts/generate-vm-report.sh
+++ b/scripts/generate-vm-report.sh
@@ -55,8 +55,8 @@ Generated: **${TIMESTAMP}** &middot; Commit: [\`${COMMIT}\`](https://github.com/
 | Resource | Value |
 |---|---|
 | CPU | $(echo "$CPU_INFO" | grep 'Model name' | sed 's/.*: *//') |
-| vCPUs | $(echo "$CPU_INFO" | grep '^CPU(s)' | awk '{print $2}') |
-| Threads/core | $(echo "$CPU_INFO" | grep 'Thread' | awk '{print $NF}') |
+| vCPUs | $(echo "$CPU_INFO" | grep '^CPU(s)' | awk '{print \$2}') |
+| Threads/core | $(echo "$CPU_INFO" | grep 'Thread' | awk '{print \$NF}') |
 | RAM | ${MEM_TOTAL} total, ${MEM_FREE} free |
 | Swap | ${SWAP} |
 


### PR DESCRIPTION
…nsion

$2 and $NF inside an unquoted <<MD heredoc are expanded by bash before awk sees them, causing the script to fail. Escape to \$2 and \$NF.