### PR TITLE
fix(vm-report): fix two bugs causing script to fail silently

### DIFF
--- a/.github/workflows/vm-report.yml
+++ b/.github/workflows/vm-report.yml
@@ -93,7 +93,7 @@ jobs:
           sleep 2; elapsed=$((elapsed + 2))
         done
         echo "VM failed to boot in time"
-        cat run-vm-output.log
+        cat run-vm-output.log || true
         exit 1
 
     - name: Generate report

--- a/scripts/generate-vm-report.sh
+++ b/scripts/generate-vm-report.sh
@@ -17,6 +17,9 @@ collect() { $SSH "$1" 2>/dev/null || echo "(not available)"; }
 KERNEL=$(collect "uname -r")
 PROC_VER=$(collect "cat /proc/version")
 CPU_INFO=$(collect "lscpu | grep -E '^CPU\(s\)|^Model name|^Thread|^Core|^Socket'")
+CPU_MODEL=$(echo "$CPU_INFO" | grep 'Model name' | sed 's/.*: *//' || echo "(not available)")
+CPU_COUNT=$(echo "$CPU_INFO" | awk '/^CPU\(s\)/{print $2}')
+CPU_THREADS=$(echo "$CPU_INFO" | awk '/Thread/{print $NF}')
 MEM=$(collect "free -h")
 MEM_TOTAL=$(echo "$MEM" | awk '/^Mem/{print $2}')
 MEM_FREE=$(echo "$MEM"  | awk '/^Mem/{print $4}')
@@ -54,9 +57,9 @@ Generated: **${TIMESTAMP}** &middot; Commit: [\`${COMMIT}\`](https://github.com/
 
 | Resource | Value |
 |---|---|
-| CPU | $(echo "$CPU_INFO" | grep 'Model name' | sed 's/.*: *//') |
-| vCPUs | $(echo "$CPU_INFO" | grep '^CPU(s)' | awk '{print \$2}') |
-| Threads/core | $(echo "$CPU_INFO" | grep 'Thread' | awk '{print \$NF}') |
+| CPU | ${CPU_MODEL} |
+| vCPUs | ${CPU_COUNT} |
+| Threads/core | ${CPU_THREADS} |
 | RAM | ${MEM_TOTAL} total, ${MEM_FREE} free |
 | Swap | ${SWAP} |
 


### PR DESCRIPTION
- Add || true to cat run-vm-output.log in the wait-for-SSH step so a missing log file does not swallow the exit 1 and let subsequent steps run when the VM failed to boot
- Pre-compute CPU model, count, and thread count before the heredoc so grep commands never run inside $() subshells under set -euo pipefail; grep returning exit 1 on no-match was killing the script when the VM had no ROCm or when lscpu output was unexpected