### PR TITLE
debug(vm-report): add set -x to trace silent script failure

### DIFF
--- a/scripts/generate-vm-report.sh
+++ b/scripts/generate-vm-report.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Generate a markdown VM inspection report from a running QEMU VM.
 # Usage: generate-vm-report.sh <output-dir> [ssh-port] [ssh-user]
-set -euo pipefail
+set -euxo pipefail
 
 OUTDIR=${1:-site}
 PORT=${2:-2222}


### PR DESCRIPTION
Script exits with code 1 in ~3s with no visible output. Adding -x to set -euxo pipefail will surface which line is failing in the GitHub Actions log.