### PR TITLE
fix(vm-report): run Jekyll to build index.html before deploying to Pages

### DIFF
--- a/.github/workflows/vm-report.yml
+++ b/.github/workflows/vm-report.yml
@@ -106,10 +106,16 @@ jobs:
     - name: Setup Pages
       uses: actions/configure-pages@v5
 
+    - name: Build Jekyll site
+      uses: github/jekyll-build-pages@v1
+      with:
+        source: site/
+        destination: _site/
+
     - name: Upload Pages artifact
       uses: actions/upload-pages-artifact@v3
       with:
-        path: site/
+        path: _site/
 
     - name: Deploy to GitHub Pages
       id: deployment


### PR DESCRIPTION
actions/upload-pages-artifact deploys static files as-is without running Jekyll, so index.md was served as raw markdown with no index.html at the root. Add a github/jekyll-build-pages@v1 step to convert site/ (markdown + _config.yml) into _site/ (HTML) before uploading the artifact.