### PR TITLE
fix(vm-report): correct Jekyll action to actions/jekyll-build-pages

### DIFF
--- a/.github/workflows/vm-report.yml
+++ b/.github/workflows/vm-report.yml
@@ -107,7 +107,7 @@ jobs:
       uses: actions/configure-pages@v5
 
     - name: Build Jekyll site
-      uses: github/jekyll-build-pages@v1
+      uses: actions/jekyll-build-pages@v1
       with:
         source: site/
         destination: _site/


### PR DESCRIPTION
github/jekyll-build-pages does not exist; the correct action is actions/jekyll-build-pages@v1.