### PR TITLE
fix(ci): pass --images to gen-vm and run-vm in vm-report workflow

### DIFF
--- a/.github/workflows/vm-report.yml
+++ b/.github/workflows/vm-report.yml
@@ -66,6 +66,7 @@ jobs:
       run: |
         qemu-tool gen-vm \
           --vm-name vm-report \
+          --images images \
           --release noble \
           --username ubuntu \
           --password password \
@@ -76,6 +77,7 @@ jobs:
       run: |
         qemu-tool run-vm \
           --vm-name vm-report \
+          --images images \
           --nvme 1 \
           > run-vm-output.log 2>&1 &
 


### PR DESCRIPTION
The vm-report job runs on ubuntu-latest without a privileged container, so the default /var/lib/qemu-tool/images path is not writable by the runner. Add --images images to both gen-vm and run-vm so they use the local images/ directory that the workflow already creates and caches.