### PR TITLE
fix(gen-vm): resolve backing path to absolute before qemu-img create

### DIFF
--- a/qemu/qemu-tool/gen_vm.py
+++ b/qemu/qemu-tool/gen_vm.py
@@ -128,7 +128,7 @@ def _restore_image(cfg: VMConfig, images: Path) -> None:
 def _create_overlay(overlay: Path, backing: Path) -> None:
     ts = _save_timestamp(backing)
     subprocess.run(
-        ["qemu-img", "create", "-F", "qcow2", "-b", str(backing), "-f", "qcow2",
+        ["qemu-img", "create", "-F", "qcow2", "-b", str(backing.resolve()), "-f", "qcow2",
          str(overlay)],
         check=True,
     )


### PR DESCRIPTION
qemu-img rejects a relative path for the -b backing file argument. When --images is given a relative directory (e.g. "images"), the backing path was also relative, causing qemu-img to fail. Use Path.resolve() to make it absolute before passing it to qemu-img.