### PR TITLE
fix(rocm-setup): consolidate ansible prep and add gpu-check toggle

### DIFF
--- a/ansible/playbooks/vm-rocm-setup.yml
+++ b/ansible/playbooks/vm-rocm-setup.yml
@@ -12,6 +12,7 @@
     rocm_setup_repo_stream: therock
     rocm_setup_skip_reboot: false
     rocm_setup_run_checks: true
+    rocm_setup_run_gpu_checks: false
     rocm_setup_install_metrics_exporter: true
     rocm_setup_extra_kernel_packages:
       - linux-generic-hwe-24.04

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: sbates130272.batesste
-    version: ">=2.2.5"
+    version: ">=2.3.0"

--- a/qemu/qemu-tool/gen_vm.py
+++ b/qemu/qemu-tool/gen_vm.py
@@ -38,6 +38,7 @@ _ARCH_MAP = {
 
 def run(cfg: VMConfig) -> None:
     _validate(cfg)
+    _prepare_ansible(cfg)
 
     images = Path(cfg.images)
     images.mkdir(parents=True, exist_ok=True)
@@ -52,7 +53,6 @@ def run(cfg: VMConfig) -> None:
         backing = images / f"{cfg.vm_name}-backing.qcow2"
         if not backing.exists():
             sys.exit(f"Error: --ansible-only requires an existing backing image at {backing}")
-        _prepare_ansible(cfg)
         _run_ansible(cfg, images, backing)
         overlay = images / f"{cfg.vm_name}.qcow2"
         if cfg.no_backing:
@@ -84,7 +84,6 @@ def run(cfg: VMConfig) -> None:
     if not ssh_key.exists():
         sys.exit(f"Error: SSH key file {ssh_key} does not exist!")
 
-    _prepare_ansible(cfg)
     packages = _load_packages(cfg)
 
     with ExitStack() as stack:


### PR DESCRIPTION
Move _prepare_ansible() call before the --ansible-only branch in gen_vm.py so it runs unconditionally rather than being duplicated in two code paths.

Add rocm_setup_run_gpu_checks variable (default false) to vm-rocm-setup.yml for environments where GPU hardware checks should be skipped.

Bump sbates130272.batesste collection requirement to >=2.3.0 to pull in the new rocm_setup_run_gpu_checks support.