### PR TITLE
fix: resolve vm-ernic-image-prep ansible issues for Ubuntu 26.04

### DIFF
--- a/.github/workflows/2vm-smoke-test.yml
+++ b/.github/workflows/2vm-smoke-test.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   ERNIC_IMAGE: docker.io/sbates130272/batesste-ci-images-ubuntu-rocm-ernic:ernic.e3ef00c-vfu.323f4cb
-  ROCJITSU_IMAGE: docker.io/sbates130272/batesste-ci-images-ubuntu-rocm-rocjitsu:rocjitsu.5e9cc7c
+  ROCJITSU_IMAGE: docker.io/sbates130272/batesste-ci-images-ubuntu-rocm-rocjitsu:rocjitsu.730bc62
   QEMU_IMAGE: docker.io/sbates130272/batesste-ci-images-ubuntu-qemu-libvfio-user:qemu11.1.1-vfu.323f4cb
   VM_IMAGES_DIR: /var/lib/qemu-tool/images
   VM1_NAME: 2vm-smoke-1

--- a/.github/workflows/2vm-vm-report.yml
+++ b/.github/workflows/2vm-vm-report.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   ERNIC_IMAGE: docker.io/sbates130272/batesste-ci-images-ubuntu-rocm-ernic:ernic.e3ef00c-vfu.323f4cb
-  ROCJITSU_IMAGE: docker.io/sbates130272/batesste-ci-images-ubuntu-rocm-rocjitsu:rocjitsu.5e9cc7c
+  ROCJITSU_IMAGE: docker.io/sbates130272/batesste-ci-images-ubuntu-rocm-rocjitsu:rocjitsu.730bc62
   QEMU_IMAGE: docker.io/sbates130272/batesste-ci-images-ubuntu-qemu-libvfio-user:qemu11.1.1-vfu.323f4cb
   VM_IMAGES_DIR: /var/lib/qemu-tool/images
   VM1_NAME: 2vm-report-1

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ review-and-push.sh
 wrap-markdown.py
 check-ci-status.sh
 PROJECT_COMPLETION_SUMMARY.md
+run-this.sh
 
 # Compose environment overrides
 .env

--- a/ansible/playbooks/vm-ernic-image-prep.yml
+++ b/ansible/playbooks/vm-ernic-image-prep.yml
@@ -2,7 +2,7 @@
 - name: Bake rocm-ernic prerequisites into a base VM image
   hosts: all
   gather_facts: true
-  become: false
+  become: true
   vars:
     username: "{{ vm_username | default('ubuntu') }}"
     root_user: "{{ vm_root_user | default('ubuntu') }}"
@@ -13,13 +13,58 @@
     rocm_setup_skip_reboot: false
     rocm_setup_run_checks: true
     rocm_setup_run_gpu_checks: false
-    rocm_setup_install_metrics_exporter: true
     rocm_setup_extra_kernel_packages:
-      - linux-generic-hwe-24.04
+      - linux-generic-hwe-26.04
     ernic_image_rdma: true
     ernic_gpu_passthrough: true
+  pre_tasks:
+    # Remove stale ROCm GPG keyring and sources so the rocm_setup role
+    # re-fetches both from scratch. Without this, idempotent key/source
+    # tasks on --ansible-only runs leave a mismatched keyring+sources pair
+    # that breaks apt-get update for all subsequent roles.
+    - name: Remove stale ROCm GPG keyrings and sources
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      become: true
+      loop:
+        - /etc/apt/keyrings/rocm.gpg
+        - /etc/apt/keyrings/amdrocm.gpg
+        - /etc/apt/sources.list.d/rocm.sources
+
+    - name: Remove any stale device-metrics-exporter apt sources
+      ansible.builtin.shell:
+        cmd: |
+          find /etc/apt/sources.list.d -type f \
+            -exec grep -l "device-metrics-exporter\|amdgpu-exporter" {} \; \
+            | xargs -r rm -f
+      become: true
+      changed_when: false
+
   roles:
     - role: sbates130272.batesste.user_setup
     - role: sbates130272.batesste.fave_packages
     - role: sbates130272.batesste.git_setup
     - role: sbates130272.rocm_ernic.ernic_image_prep
+
+  post_tasks:
+    # The device-metrics-exporter repo has no resolute suite yet; pin to noble.
+    - name: Add device-metrics-exporter apt source (noble suite)
+      ansible.builtin.copy:
+        dest: /etc/apt/sources.list.d/device-metrics-exporter.sources
+        content: |
+          Types: deb
+          URIs: https://repo.radeon.com/device-metrics-exporter/apt/1.5.1
+          Suites: noble
+          Components: main
+          Architectures: amd64
+          Signed-By: /etc/apt/keyrings/rocm.gpg
+        mode: '0644'
+      become: true
+
+    - name: Install AMD Device Metrics Exporter
+      ansible.builtin.package:
+        name: amdgpu-exporter
+        state: present
+        update_cache: true
+      become: true

--- a/ansible/profiles/vm-ernic-image-prep
+++ b/ansible/profiles/vm-ernic-image-prep
@@ -1,1 +1,2 @@
 ANSIBLE_PLAYBOOK=playbooks/vm-ernic-image-prep.yml
+ANSIBLE_EXTRA_ARGS=-e {"rocm_setup_install_metrics_exporter":false}

--- a/qemu/qemu-tool/gen_vm.py
+++ b/qemu/qemu-tool/gen_vm.py
@@ -507,15 +507,25 @@ def _wait_for_ssh(cfg: VMConfig, timeout: int) -> bool:
     print(f"Waiting for VM to accept SSH on port {cfg.ssh_port}...")
     elapsed = 0
     while elapsed < timeout:
-        r = subprocess.run(
-            ["ssh", "-o", "ConnectTimeout=1",
-             "-o", "StrictHostKeyChecking=no",
-             "-o", "UserKnownHostsFile=/dev/null",
-             "-p", str(cfg.ssh_port),
-             f"{cfg.username}@localhost", "true"],
-            capture_output=True,
-        )
-        if r.returncode == 0:
+        try:
+            r = subprocess.run(
+                ["ssh",
+                 "-o", "BatchMode=yes",
+                 "-o", "ConnectTimeout=1",
+                 "-o", "StrictHostKeyChecking=no",
+                 "-o", "UserKnownHostsFile=/dev/null",
+                 "-p", str(cfg.ssh_port),
+                 f"{cfg.username}@localhost", "true"],
+                capture_output=True,
+                timeout=5,
+            )
+            if r.returncode == 0:
+                print(f"VM ready for Ansible after {elapsed} seconds.")
+                return True
+        except subprocess.TimeoutExpired:
+            # SSH connected (ConnectTimeout=1 would have fired otherwise)
+            # but background login processes kept the channel open.
+            # The VM is up.
             print(f"VM ready for Ansible after {elapsed} seconds.")
             return True
         time.sleep(2)


### PR DESCRIPTION
## Summary

- Fix `vm-ernic-image-prep` Ansible playbook to work on Ubuntu 26.04 (Resolute), resolving a chain of failures encountered during VM image baking for the rocm-ernic 2VM compose stack.
- Fix `_wait_for_ssh` in `qemu-tool` hanging indefinitely when login scripts spawn background processes that keep the SSH channel open (broke `--ansible-only` runs).
- Bump rocjitsu CI image tag to `rocjitsu.730bc62` in both 2vm workflows.

## Changes

**ansible/playbooks/vm-ernic-image-prep.yml**
- `become: true` at play level — `ernic_image_prep` role tasks lack per-task become, causing apt lock permission failures
- HWE kernel package updated from `linux-generic-hwe-24.04` to `linux-generic-hwe-26.04`
- `pre_tasks`: purge stale ROCm GPG keyrings (`rocm.gpg`, `amdrocm.gpg`) and `rocm.sources` before each run — prevents `--ansible-only` runs leaving a mismatched keyring+sources pair that breaks subsequent apt-get update calls
- `pre_tasks`: remove any stale device-metrics-exporter apt sources via `find`
- `post_tasks`: install `amdgpu-exporter` via a manually added noble-suite source (resolute suite not yet published upstream)

**ansible/profiles/vm-ernic-image-prep**
- Pass `rocm_setup_install_metrics_exporter=false` via `ANSIBLE_EXTRA_ARGS` (highest Ansible precedence) — overrides the `include_role vars:` block inside `ernic_image_prep` that unconditionally forces it true, preventing the resolute metrics-exporter repo from poisoning apt cache updates

**qemu/qemu-tool/gen_vm.py**
- `_wait_for_ssh`: add `BatchMode=yes` and `timeout=5` to the SSH probe subprocess — login scripts (e.g. dynamic MOTD) can spawn background processes that keep the SSH channel open indefinitely, causing `subprocess.run` to hang; a `TimeoutExpired` after 5 s now correctly signals that SSH is up

## Test plan

- [ ] `bash run-this.sh --ansible-only` completes with `failed=0` on a resolute backing image
- [ ] Both VMs come up with ernic DKMS modules loaded and GPU visible to ROCm after a full run
