### PR TITLE
fix(ci): add qemu-system-x86 to ernic/rocjitsu job packages

### DIFF
--- a/.github/workflows/ansible-playbook-test.yml
+++ b/.github/workflows/ansible-playbook-test.yml
@@ -149,7 +149,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y -qq \
-          qemu-utils cloud-image-utils \
+          qemu-system-x86 qemu-utils cloud-image-utils \
           ansible openssh-client python3-pip
 
     - name: Install jmespath for Ansible json_query filter
@@ -301,7 +301,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y -qq \
-          qemu-utils cloud-image-utils \
+          qemu-system-x86 qemu-utils cloud-image-utils \
           ansible openssh-client python3-pip
 
     - name: Install jmespath for Ansible json_query filter
@@ -463,7 +463,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt-get install -y -qq \
-          qemu-utils cloud-image-utils \
+          qemu-system-x86 qemu-utils cloud-image-utils \
           ansible openssh-client python3-pip
 
     - name: Install jmespath for Ansible json_query filter


### PR DESCRIPTION
gen-vm runs cloud-init on the host even when QEMU runs in a compose
container for the test stage. The three ernic/rocjitsu jobs were missing
`qemu-system-x86` from their apt-get install list, causing a
`FileNotFoundError` at the gen-vm phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)