### PR TITLE
fix(ci): pass GITHUB_TOKEN to gen-vm steps in ansible-playbook-test

### DIFF
--- a/.github/workflows/ansible-playbook-test.yml
+++ b/.github/workflows/ansible-playbook-test.yml
@@ -79,6 +79,8 @@ jobs:
       run: sudo mkdir -p "$VM_IMAGES_DIR" && sudo chmod 777 "$VM_IMAGES_DIR"
 
     - name: Generate VM with vm-rocm playbook
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         qemu-tool gen-vm \
           --vm-name rocm-test \
@@ -191,6 +193,8 @@ jobs:
         docker pull "$QEMU_IMAGE"
 
     - name: Generate VM with vm-ernic playbook (install stage)
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         qemu-tool gen-vm \
           --vm-name ernic-test \
@@ -338,6 +342,8 @@ jobs:
         docker pull "$QEMU_IMAGE"
 
     - name: Generate VM with vm-rocjitsu playbook
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         qemu-tool gen-vm \
           --vm-name rocjitsu-test \
@@ -494,6 +500,8 @@ jobs:
         docker pull "$QEMU_IMAGE"
 
     - name: Generate VM with vm-ernic-rocjitsu playbook
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         qemu-tool gen-vm \
           --vm-name ernic-rocjitsu-test \


### PR DESCRIPTION
## Summary

- Add `GITHUB_TOKEN` to the `env` block of all four `qemu-tool gen-vm` steps in `ansible-playbook-test.yml` (rocm, ernic, rocjitsu, ernic-rocjitsu jobs)
- Ansible roles that call the GitHub API (e.g. `user_setup` dotfiles release lookup via `ansible.builtin.uri`) hit rate limits or fail with anonymous-access errors in CI without an authenticated token

## Test plan

- [ ] Confirm the rocm, ernic, rocjitsu, and ernic-rocjitsu CI jobs complete without GitHub API rate-limit or authentication errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
